### PR TITLE
added rx_sec and tx_sec support for OSX

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -507,6 +507,40 @@ exports.network_speed = function(interface, callback) {
     			}
     		});
     	} else callback(null);
+    } else {
+        var cmd = "netstat -ibI " + iface;
+        exec(cmd, function(error, stdout, stderr) {
+            if (!error) {
+                var lines = stdout.toString().split('\n');
+                // if there is less than 2 lines, no information for this interface was found
+                if (lines.length > 1) {
+                    // skip header line
+                    // TODO: operstate
+                    // use the second line because it is tied to the NIC instead of the ipv4 or ipv6 address
+                    var stats = lines[1].replace(/ +/g, " ").split(' ');
+                    var rx = parseInt(stats[6]);
+                    var tx = parseInt(stats[9]);
+
+                    if (tmp_network["iface"]) {
+                        var ms = Date.now() - tmp_network["iface"].ms;
+                        rx_sec = (rx - tmp_network["iface"].rx) / (ms / 1000);
+                        tx_sec = (tx - tmp_network["iface"].tx) / (ms / 1000);
+                    } else {
+                        rx_sec = 0;
+                        tx_sec = 0;
+                        tmp_network["iface"] = {};
+                    }
+                    tmp_network["iface"].rx = rx;
+                    tmp_network["iface"].tx = tx;
+                    tmp_network["iface"].ms = Date.now();
+
+                    callback({
+                        rx_sec : rx_sec,
+                        tx_sec : tx_sec
+                    });
+                }
+            }
+        });
     } else callback(null);
 }
 


### PR DESCRIPTION
Added  si.network_speed(iface).rx_sec and tx_sec support for OSX using netstat.
This implementation has a lot of code re-use and can be cleaned-up. 
Note: operstate is still not supported.