### PR TITLE
Add idle to cpus result object [Accuracy not verified]

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ si.cpu()
 
 - Version 3.17.0: windows support for some very first functions (work in progress)
 - Version 3.16.0: `blockDevices`: added removable attribute
-- Version 3.15.0: added `cpuTemperature` also for OSX 
-- Version 3.14.0: added `currentLoad` per cpu/core, cpu cache (L1, L2, L3) and cpu flags 
+- Version 3.15.0: added `cpuTemperature` also for OSX
+- Version 3.14.0: added `currentLoad` per cpu/core, cpu cache (L1, L2, L3) and cpu flags
 - Version 3.13.0: added `shell` (returns standard shell)
 - Version 3.12.0: refactoring and extended `currentLoad` (better OSX coverage and added irq load).
 - Version 3.11.0: `blockDevices` now also for OSX and also extended (+ label, model, serial, protocol).
@@ -72,7 +72,7 @@ little library. This library is still work in progress. Version 3 comes with fur
 requires now node.js version 4.0 and above. Another big change is, that all functions now return promises. You can use them
 like before with callbacks OR with promises (see example in this documentation). I am sure, there is for sure room for improvement.
 I was only able to test it on several Debian, Raspbian, Ubuntu distributions as well as OS X (Mavericks, Yosemite, El Captain).
-Since version 2 nearly all functionality is available on OS X/Darwin platforms. 
+Since version 2 nearly all functionality is available on OS X/Darwin platforms.
 Be careful, this library has only very limited Windows support!
 
 If you have comments, suggestions & reports, please feel free to contact me!
@@ -276,8 +276,8 @@ This library is splitted in several sections:
 | - [0].time | X | X |  | login time |
 | - [0].ip | X | X |  | ip address (remote login) |
 | - [0].command | X | X |  | last command or shell |
-| si.inetChecksite(url, cb) | X | X |  | response-time (ms) to fetch given URL |
-| - url | X | X |  | given url |
+| si.inetChecksite(options, cb) | X | X |  | response-time (ms) to fetch given URL |
+| - options | X | X |  | { url: 'google.com', flags: '--interface c'} <br> { url: 'google.com', flags: {'--interface': 'c', '-H': 'content-type:application/json'}|
 | - ok | X | X |  | status code OK (2xx, 3xx) |
 | - status | X | X |  | status code |
 | - ms | X | X |  | response time in ms |
@@ -400,9 +400,9 @@ Written by Sebastian Hildebrandt [sebhildebrandt](https://github.com/sebhildebra
 - csy [csy](https://github.com/csy1983)
 
 OSX Temperature: Credits here are going to:
- 
+
 - Massimiliano Marcon [mmarcon](https://github.com/mmarcon) - for his work on [smc-code][smc-code-url]
-- Sébastien Lavoie[lavoiesl](https://github.com/lavoiesl) for his work on [osx-cpu-temp][osx-cpu-temp-url] code. 
+- Sébastien Lavoie[lavoiesl](https://github.com/lavoiesl) for his work on [osx-cpu-temp][osx-cpu-temp-url] code.
 
 ## Copyright Information
 

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -453,6 +453,7 @@ function getLoad() {
           let tmp_user = (_cpus && _cpus[i] && _cpus[i].user ? _cpus[i].user : 0);
           let tmp_system = (_cpus && _cpus[i] && _cpus[i].sys ? _cpus[i].sys : 0);
           let tmp_nice = (_cpus && _cpus[i] && _cpus[i].nice ? _cpus[i].nice : 0);
+          let tmp_idle = (_cpus && _cpus[i] && _cpus[i].idle ? _cpus[i].idle : 0);
           let tmp_irq = (_cpus && _cpus[i] && _cpus[i].irq ? _cpus[i].irq : 0);
           _cpus[i] = cpu;
           _cpus[i].totalTick = _cpus[i].user + _cpus[i].sys + _cpus[i].nice + _cpus[i].irq + _cpus[i].idle;
@@ -462,12 +463,14 @@ function getLoad() {
           _cpus[i].load_user = (_cpus[i].user - tmp_user) / _cpus[i].currentTick * 100;
           _cpus[i].load_system = (_cpus[i].sys - tmp_system) / _cpus[i].currentTick * 100;
           _cpus[i].load_nice = (_cpus[i].nice - tmp_nice) / _cpus[i].currentTick * 100;
+          _cpus[i].load_idle = (_cpus[i].idle - tmp_idle) / _cpus[i].currentTick * 100;
           _cpus[i].load_irq = (_cpus[i].irq - tmp_irq) / _cpus[i].currentTick * 100;
           cores[i] = {};
           cores[i].load = _cpus[i].load;
           cores[i].load_user = _cpus[i].load_user;
           cores[i].load_system = _cpus[i].load_system;
           cores[i].load_nice = _cpus[i].load_nice;
+          cores[i].load_idle = _cpus[i].load_idle;
           cores[i].load_irq = _cpus[i].load_irq;
         }
         let totalTick = totalUser + totalSystem + totalNice + totalIrq + totalIdle;
@@ -505,6 +508,7 @@ function getLoad() {
           cores[i].load_user = _cpus[i].load_user;
           cores[i].load_system = _cpus[i].load_system;
           cores[i].load_nice = _cpus[i].load_nice;
+          cores[i].load_idle = _cpus[i].load_idle;
           cores[i].load_irq = _cpus[i].load_irq;
         }
         result = {

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -26,7 +26,7 @@ const NOT_SUPPORTED = 'not supported';
 // --------------------------
 // check if external site is available
 
-function inetChecksite(url, callback) {
+function inetChecksite(options, callback) {
 
   return new Promise((resolve, reject) => {
     process.nextTick(() => {
@@ -37,15 +37,31 @@ function inetChecksite(url, callback) {
       }
 
       let result = {
-        url: url,
         ok: false,
         status: 404,
         ms: -1
       };
-      if (url) {
+
+      if (options.url) {
+        result.url = options.url;
+        let optionString = "";
         let t = Date.now();
-        let args = " -I --connect-timeout 5 -m 5 " + url + " 2>/dev/null | head -n 1 | cut -d ' ' -f2";
-        let cmd = "curl";
+        let cmd = "curl ";
+        if (options.flags) {
+          if (options.flags.constructor === Object) {
+            for (let k in options.flags) {
+              optionString += k + " " + options.flags[k] + " ";
+            }
+          } else if (options.flags.constructor === String) {
+            optionString += options.flags;
+          } else {
+            throw new Error ("flags expecting an Object or String.")
+          }
+        }
+        if (optionString) {
+          cmd += optionString;
+        }
+        let args = " -I --connect-timeout 5 -m 5 " + options.url + " 2>/dev/null | head -n 1 | cut -d ' ' -f2";
         exec(cmd + args, function (error, stdout) {
           let statusCode = parseInt(stdout.toString());
           result.status = statusCode || 404;


### PR DESCRIPTION
Hi,

I happen to be using your module and needed the `idle` field for each CPU.

So I thought I'd better implement it first rather than asking for the feature.

I have made the necessary changes but I am not familiar with the formula on how to get the accurate calculation of the idle reading.

Please review the added lines when you have a minute.

Many thanks :-)