### PR TITLE
Add options to networkStats, to enable/disable default ifacename

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ si.cpu()
 
 - Version 3.17.0: windows support for some very first functions (work in progress)
 - Version 3.16.0: `blockDevices`: added removable attribute
-- Version 3.15.0: added `cpuTemperature` also for OSX 
-- Version 3.14.0: added `currentLoad` per cpu/core, cpu cache (L1, L2, L3) and cpu flags 
+- Version 3.15.0: added `cpuTemperature` also for OSX
+- Version 3.14.0: added `currentLoad` per cpu/core, cpu cache (L1, L2, L3) and cpu flags
 - Version 3.13.0: added `shell` (returns standard shell)
 - Version 3.12.0: refactoring and extended `currentLoad` (better OSX coverage and added irq load).
 - Version 3.11.0: `blockDevices` now also for OSX and also extended (+ label, model, serial, protocol).
@@ -72,7 +72,7 @@ little library. This library is still work in progress. Version 3 comes with fur
 requires now node.js version 4.0 and above. Another big change is, that all functions now return promises. You can use them
 like before with callbacks OR with promises (see example in this documentation). I am sure, there is for sure room for improvement.
 I was only able to test it on several Debian, Raspbian, Ubuntu distributions as well as OS X (Mavericks, Yosemite, El Captain).
-Since version 2 nearly all functionality is available on OS X/Darwin platforms. 
+Since version 2 nearly all functionality is available on OS X/Darwin platforms.
 Be careful, this library has only very limited Windows support!
 
 If you have comments, suggestions & reports, please feel free to contact me!
@@ -217,8 +217,8 @@ This library is splitted in several sections:
 | - [0].mac | X | X |  | MAC address |
 | - [0].internal | X | X |  | true if internal interface |
 | si.networkInterfaceDefault(cb) | X | X |  | get name of default network interface |
-| si.networkStats(iface,cb) | X | X |  | current network stats of given interface<br>iface parameter is optional<br>defaults to first external network interface|
-| - iface | X | X |  | interface |
+| si.networkStats(options,cb) | X | X |  | current network stats of given interface<br>options parameter is optional<br>defaults to first external network interface|
+| - options | X | X |  | options(Object) {iface: 'eth0', useDefaultIface: false}<br> When useDefaultIface is false, it will return the name of whatever iface was given.
 | - operstate | X | X |  | up / down |
 | - rx | X | X |  | received bytes overall |
 | - tx | X | X |  | transferred bytes overall|
@@ -400,9 +400,9 @@ Written by Sebastian Hildebrandt [sebhildebrandt](https://github.com/sebhildebra
 - csy [csy](https://github.com/csy1983)
 
 OSX Temperature: Credits here are going to:
- 
+
 - Massimiliano Marcon [mmarcon](https://github.com/mmarcon) - for his work on [smc-code][smc-code-url]
-- Sébastien Lavoie[lavoiesl](https://github.com/lavoiesl) for his work on [osx-cpu-temp][osx-cpu-temp-url] code. 
+- Sébastien Lavoie[lavoiesl](https://github.com/lavoiesl) for his work on [osx-cpu-temp][osx-cpu-temp-url] code.
 
 ## Copyright Information
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -153,12 +153,11 @@ function calcNetworkSpeed(iface, rx, tx, operstate) {
   return result;
 }
 
-function networkStats(iface, callback) {
-
+function networkStats(options, callback) {
   // fallback - if only callback is given
-  if (util.isFunction(iface) && !callback) {
-    callback = iface;
-    iface = '';
+  if (util.isFunction(options) && !callback) {
+    callback = options;
+    options = null;
   }
 
   return new Promise((resolve, reject) => {
@@ -169,8 +168,14 @@ function networkStats(iface, callback) {
         reject(error);
       }
 
-      _default_iface = _default_iface || getDefaultNetworkInterface();
-      iface = iface || _default_iface; // (_darwin ? 'en0' : 'eth0');
+      let iface;
+
+      if (options && options.iface && options.useDefaultIface === false) {
+        iface = options.iface;
+      } else {
+        _default_iface = _default_iface || getDefaultNetworkInterface();
+        iface = iface || _default_iface; // (_darwin ? 'en0' : 'eth0');
+      }
 
       let result = {
         iface: iface,


### PR DESCRIPTION
networkStats ignores the iface argument and returns the default iface.

Usage:

```
si.networkStats() 
// { iface: 'wlp2s0',
```

```
si.networkStats({
  iface: 'custom-iface'
}) 
// { iface: 'wlp2s0',
```

```
si.networkStats({
  iface: 'custom-iface',
  useDefaultIface: false
}) 
// { iface: 'custom-iface',
```

