### PR TITLE
Using absolute path to wmic

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -116,7 +116,7 @@ module.exports = function (callback) {
         });
       }
       if (_windows) {
-        exec("WMIC Path Win32_Battery Get BatteryStatus, DesignCapacity, EstimatedChargeRemaining /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\WMIC Path Win32_Battery Get BatteryStatus, DesignCapacity, EstimatedChargeRemaining /value", function (error, stdout) {
           if (stdout) {
             let lines = stdout.split('\r\n');
             let status = getValue(lines, 'BatteryStatus', '=').trim();

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -157,7 +157,7 @@ function getCpu() {
         })
       }
       if (_windows) {
-        exec("wmic cpu get name, description, revision, l2cachesize, l3cachesize, manufacturer, currentclockspeed, maxclockspeed /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic cpu get name, description, revision, l2cachesize, l3cachesize, manufacturer, currentclockspeed, maxclockspeed /value", function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n');
             let name = getValue(lines, 'name', '=') || '';
@@ -340,7 +340,7 @@ function cpuTemperature(callback) {
         resolve(result);
       }
       if (_windows) {
-        exec("wmic /namespace:\\\\root\\wmi PATH MSAcpi_ThermalZoneTemperature get CriticalTripPoint,CurrentTemperature /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic /namespace:\\\\root\\wmi PATH MSAcpi_ThermalZoneTemperature get CriticalTripPoint,CurrentTemperature /value", function (error, stdout) {
           if (!error) {
             let sum = 0;
             let lines = stdout.trim().split(/\s\s+/);
@@ -471,7 +471,7 @@ function cpuCache(callback) {
         });
       }
       if (_windows) {
-        exec("wmic cpu get l2cachesize, l3cachesize /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic cpu get l2cachesize, l3cachesize /value", function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n');
             result.l2 = getValue(lines, 'l2cachesize', '=');

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -84,7 +84,7 @@ function fsSize(callback) {
         });
       }
       if (_windows) {
-        exec('wmic logicaldisk get Caption,FileSystem,FreeSpace,Size', function (error, stdout) {
+        exec('%SystemRoot%\\system32\\wbem\\wmic logicaldisk get Caption,FileSystem,FreeSpace,Size', function (error, stdout) {
           let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
           lines.forEach(function (line) {
             if (line !== '') {
@@ -257,7 +257,7 @@ function blockDevices(callback) {
         });
       }
       if (_windows) {
-        exec('wmic logicaldisk get Caption,Description,DeviceID,DriveType,FileSystem,FreeSpace,Name,Size,VolumeName,VolumeSerialNumber /format:csv', function (error, stdout) {
+        exec('%SystemRoot%\\system32\\wbem\\wmic logicaldisk get Caption,Description,DeviceID,DriveType,FileSystem,FreeSpace,Name,Size,VolumeName,VolumeSerialNumber /format:csv', function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
             lines.forEach(function (line) {
@@ -665,7 +665,7 @@ function diskLayout(callback) {
       }
       if (_windows) {
 
-        exec("wmic diskdrive get /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic diskdrive get /value", function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('\r\n\r\n\r\n');
             devices.forEach(function (device) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -313,7 +313,7 @@ function graphics(callback) {
       }
       if (_windows) {
         // https://blogs.technet.microsoft.com/heyscriptingguy/2013/10/03/use-powershell-to-discover-multi-monitor-information/
-        exec("wmic path win32_VideoController get AdapterCompatibility, AdapterDACType, name, PNPDeviceID, CurrentVerticalResolution, CurrentHorizontalResolution, CurrentNumberOfColors, AdapterRAM, CurrentBitsPerPixel, CurrentRefreshRate, MinRefreshRate, MaxRefreshRate /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic path win32_VideoController get AdapterCompatibility, AdapterDACType, name, PNPDeviceID, CurrentVerticalResolution, CurrentHorizontalResolution, CurrentNumberOfColors, AdapterRAM, CurrentBitsPerPixel, CurrentRefreshRate, MinRefreshRate, MaxRefreshRate /value", function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n');
             result.controllers.push({});

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -173,7 +173,7 @@ function mem(callback) {
       if (_windows) {
         let swaptotal = 0;
         let swapused = 0;
-        exec("wmic pagefile get AllocatedBaseSize, CurrentUsage", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic pagefile get AllocatedBaseSize, CurrentUsage", function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
             lines.forEach(function (line) {
@@ -263,7 +263,7 @@ function memLayout(callback) {
         const memoryTypes = 'Unknown|Other|DRAM|Synchronous DRAM|Cache DRAM|EDO|EDRAM|VRAM|SRAM|RAM|ROM|FLASH|EEPROM|FEPROM|EPROM|CDRAM|3DRAM|SDRAM|SGRAM|RDRAM|DDR|DDR2|DDR2 FB-DIMM|Reserved|DDR3|FBD2|DDR4|LPDDR|LPDDR2|LPDDR3|LPDDR4'.split('|')
         const FormFactors = 'Unknown|Other|SIP|DIP|ZIP|SOJ|Proprietary|SIMM|DIMM|TSOP|PGA|RIMM|SODIMM|SRIMM|SMD|SSMP|QFP|TQFP|SOIC|LCC|PLCC|BGA|FPBGA|LGA'.split('|');
 
-        exec("wmic memorychip get BankLabel, Capacity, ConfiguredClockSpeed, ConfiguredVoltage, MaxVoltage, MinVoltage, DataWidth, FormFactor, Manufacturer, MemoryType, PartNumber, SerialNumber, Speed, Tag /value", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic memorychip get BankLabel, Capacity, ConfiguredClockSpeed, ConfiguredVoltage, MaxVoltage, MinVoltage, DataWidth, FormFactor, Manufacturer, MemoryType, PartNumber, SerialNumber, Speed, Tag /value", function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('BankL');
             devices.shift();

--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -202,7 +202,7 @@ function osInfo(callback) {
       if (_windows) {
         result.logofile = getLogoFile();
         result.release = result.kernel;
-        exec("wmic os get Caption", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic os get Caption", function (error, stdout) {
           result.distro = result.codename = stdout.slice(stdout.indexOf('\r\n') + 2).trim();
           if (callback) {
             callback(result)

--- a/lib/system.js
+++ b/lib/system.js
@@ -144,7 +144,7 @@ module.exports = function (callback) {
         })
       }
       if (_windows) {
-        exec("wmic csproduct get", function (error, stdout) {
+        exec("%SystemRoot%\\system32\\wbem\\wmic csproduct get", function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0)[0].trim().split(/\s\s+/);
             result.manufacturer = lines[5];


### PR DESCRIPTION
wmic is not always in `path`, and hence usages of this do not always return the correct information. 
The path to wmic doesn't seem to have changed, so absolute path should be safe.