### PR TITLE
Windows si.graphics() fixes

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -327,6 +327,9 @@ function graphics(callback) {
             result.displays[0].resolutiony = getValue(lines, 'CurrentVerticalResolution', '=');
             result.displays[0].depth = getValue(lines, 'CurrentBitsPerPixel', '=');
           }
+          if (callback) {
+            callback(result)
+          }
           resolve(result);
         })
       }

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -315,27 +315,55 @@ function graphics(callback) {
         // https://blogs.technet.microsoft.com/heyscriptingguy/2013/10/03/use-powershell-to-discover-multi-monitor-information/
         exec("wmic path win32_VideoController get AdapterCompatibility, AdapterDACType, name, PNPDeviceID, CurrentVerticalResolution, CurrentHorizontalResolution, CurrentNumberOfColors, AdapterRAM, CurrentBitsPerPixel, CurrentRefreshRate, MinRefreshRate, MaxRefreshRate /value", function (error, stdout) {
           if (!error) {
-            let lines = stdout.split('\r\n');
-            result.controllers.push({});
-            result.displays.push({});
-            result.controllers[0].model = getValue(lines, 'name', '=');
-            result.controllers[0].vendor = getValue(lines, 'AdapterCompatibility', '=');
-            result.controllers[0].bus = getValue(lines, 'PNPDeviceID', '=').startsWith('PCI') ? 'PCI' : '';
-            result.controllers[0].vram = getValue(lines, 'AdapterRAM', '=');
-
-            result.displays[0].resolutionx = getValue(lines, 'CurrentHorizontalResolution', '=');
-            result.displays[0].resolutiony = getValue(lines, 'CurrentVerticalResolution', '=');
-            result.displays[0].depth = getValue(lines, 'CurrentBitsPerPixel', '=');
+            let csections = stdout.split(/\n\s*\n/);
+            result.controllers = parseLinesWindowsControllers(csections);
+            exec("wmic path win32_desktopmonitor get MonitorManufacturer, ScreenWidth, ScreenHeight /value", function (error, stdout) {
+              let dsections = stdout.split(/\n\s*\n/);
+              if (!error) {
+                result.displays = parseLinesWindowsDisplays(dsections);
+              }
+              if (callback) {
+                callback(result)
+              }
+              resolve(result);
+            })
           }
-          if (callback) {
-            callback(result)
-          }
-          resolve(result);
         })
       }
 
     });
   });
+
+  function parseLinesWindowsControllers(sections){
+    let controllers = [];
+    for (let i in sections) {
+      if (sections[i].trim() != "") {
+        let lines = sections[i].trim().split('\r\n');
+        controllers.push({
+          model: getValue(lines, 'name', '='),
+          vendor: getValue(lines, 'AdapterCompatibility', '='),
+          bus: getValue(lines, 'PNPDeviceID', '=').startsWith('PCI') ? 'PCI' : '',
+          vram: getValue(lines, 'AdapterRAM', '=')
+        });
+      }
+    }
+    return controllers;
+  }
+
+  function parseLinesWindowsDisplays(sections){
+    let displays = [];
+    for (let i in sections) {
+      if (sections[i].trim() != "") {
+        let lines = sections[i].trim().split('\r\n');
+        displays.push({
+          model: getValue(lines, 'MonitorManufacturer', '='),
+          resolutionx: getValue(lines, 'ScreenWidth', '='),
+          resolutiony: getValue(lines, 'ScreenHeight', '=')
+        });
+      }
+    }
+    return displays;
+  }
 }
 
 exports.graphics = graphics;


### PR DESCRIPTION
* Fixes `si.graphics()` on Windows to execute callback. Currently, it never calls the callback, and possibly does an infinite load on some UIs
* Updated `.controllers` and `.displays` for Windows
  * Now returns multiple displays, and controllers
  * Display detection is now a separate call, using `win32_VideoController`
* Still known problems not fixed on this PR
  * :warning: Fields still incomplete for Windows compared to other OS
  * :warning: Vram size cannot exceed the 32-bit limit because of `win32_VideoController`'s uint32 data type. Becomes negative when exceeds.