### PR TITLE
Revise getName function

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -178,15 +178,15 @@ function processes(callback) {
 
   function getName(command) {
     command = command || '';
-    let result = command.split(' ');
+    let result = command.split(' ')[0];
     if (result.substr(-1) === ':') {
       result = result.substr(0, result.length - 1);
     }
     if (result.substr(0,1) !== '[') {
-      let parts = part.split('/');
-      result = parts[parts.length];
+      let parts = result.split('/');
+      result = parts[parts.length - 1];
     }
-    return result
+    return result;
   }
 
   function parseLine(line) {


### PR DESCRIPTION
This commit fixes the broken points in the **getName** function, which are calling undeclared variables and accessing index out of bound.

I tested the function by manual and the results are like below.

| Input        | Output           |
| ------------- |:-------------:|
| /lib/systemd/systemd-udevd      | systemd-udevd |
| /usr/lib/linux-tools/4.10.0-32-generic/hv_kvp_daemon -n     | hv_kvp_daemon      |
| node /home/delightroom/alarmy-api/bin/www | node      |
| /lib/systemd/systemd --user | systemd | 
 