### PR TITLE
fix: parse sizeString if it has a value only

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -584,8 +584,8 @@ function diskLayout(callback) {
               }
 
               const sizeString = util.getValue(lines, 'size', ':', true).trim();
-              const sizeValue = sizeString.match(/\(([^)]+)\)/)[1];
               if (sizeString && lines.length > 0 && lines[0].trim() === 'disk') {
+                const sizeValue = sizeString.match(/\(([^)]+)\)/)[1];
                 result.push({
                   type: (mediumType === '0' ? 'SSD' : (mediumType === '1' ? 'HD' : (device.indexOf('SSD') > -1 ? 'SSD' : 'HD'))), // to be tested ... /sys/block/sda/queue/rotational
                   name: util.getValue(lines, 'product:', ':', true),


### PR DESCRIPTION
## Pull Request

Fixes https://github.com/sebhildebrandt/mmon/issues/1

#### Changes proposed:

* [x ] Fix
* [ ] Add
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

This PR simply moves the line with parsing the size information inside the if guard statement

