### PR TITLE
Fix typo that caused ischarging to be inaccurate

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -100,7 +100,7 @@ module.exports = function (callback) {
         exec('ioreg -n AppleSmartBattery -r | egrep "CycleCount|IsCharging|MaxCapacity|CurrentCapacity";pmset -g batt | grep %', function (error, stdout) {
           let lines = stdout.toString().replace(/ +/g, '').replace(/"+/g, '').replace(/-/g, '').split('\n');
           result.cyclecount = parseInt('0' + util.getValue(lines,'cyclecount', '='), 10);
-          result.ischarging = util.getValue(lines,'ischarging', '=').toLowerCase === 'yes';
+          result.ischarging = util.getValue(lines,'ischarging', '=').toLowerCase() === 'yes';
           result.maxcapacity = parseInt('0' + util.getValue(lines,'maxcapacity', '='), 10);
           result.currentcapacity = parseInt('0' + util.getValue(lines,'currentcapacity', '='), 10);
           let percent = -1;


### PR DESCRIPTION
## Pull Request

Fixes #109 

#### Changes proposed:

* [x] Fix
* [ ] Add
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

battery.ischarging would sometimes be inaccurate on macOS due to a typo.

`util.getValue(lines,'ischarging', '=').toLowerCase === 'yes'` would always return false because `util.getValue(lines,'ischarging', '=').toLowerCase` returned a `function` when it should have been `.toLowerCase()`. Small fix 👍 

