### PR TITLE
Add windowsHide: true to exec options, don't spawn windows on windows

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -24,6 +24,10 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
+const opts = {
+  windowsHide: true
+};
+
 module.exports = function (callback) {
 
   return new Promise((resolve) => {
@@ -45,22 +49,22 @@ module.exports = function (callback) {
           battery_path = '/sys/class/power_supply/BAT0/';
         }
         if (battery_path) {
-          exec('cat ' + battery_path + 'status', function (error, stdout) {
+          exec('cat ' + battery_path + 'status', opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               if (lines.length > 0 && lines[0]) result.ischarging = (lines[0].trim().toLowerCase() === 'charging');
             }
-            exec('cat ' + battery_path + 'cyclec_ount', function (error, stdout) {
+            exec('cat ' + battery_path + 'cyclec_ount', opts, function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().split('\n');
                 if (lines.length > 0 && lines[0]) result.cyclecount = parseFloat(lines[0].trim());
               }
-              exec('cat ' + battery_path + 'charge_full', function (error, stdout) {
+              exec('cat ' + battery_path + 'charge_full', opts, function (error, stdout) {
                 if (!error) {
                   let lines = stdout.toString().split('\n');
                   if (lines.length > 0 && lines[0]) result.maxcapacity = parseFloat(lines[0].trim());
                 }
-                exec('cat ' + battery_path + 'charge_now', function (error, stdout) {
+                exec('cat ' + battery_path + 'charge_now', opts, function (error, stdout) {
                   if (!error) {
                     let lines = stdout.toString().split('\n');
                     if (lines.length > 0 && lines[0]) result.currentcapacity = parseFloat(lines[0].trim());
@@ -81,7 +85,7 @@ module.exports = function (callback) {
         }
       }
       if (_freebsd || _openbsd) {
-        exec('sysctl hw.acpi.battery hw.acpi.acline', function (error, stdout) {
+        exec('sysctl hw.acpi.battery hw.acpi.acline', opts, function (error, stdout) {
           let lines = stdout.toString().split('\n');
           const batteries = parseInt('0' + util.getValue(lines,'hw.acpi.battery.units'), 10);
           const percent = parseInt('0' + util.getValue(lines,'hw.acpi.battery.life'), 10);
@@ -97,7 +101,7 @@ module.exports = function (callback) {
       }
 
       if (_darwin) {
-        exec('ioreg -n AppleSmartBattery -r | egrep "CycleCount|IsCharging|MaxCapacity|CurrentCapacity"; pmset -g batt | grep %', function (error, stdout) {
+        exec('ioreg -n AppleSmartBattery -r | egrep "CycleCount|IsCharging|MaxCapacity|CurrentCapacity"; pmset -g batt | grep %', opts, function (error, stdout) {
           if (stdout) {
             let lines = stdout.toString().replace(/ +/g, '').replace(/"+/g, '').replace(/-/g, '').split('\n');
             result.cyclecount = parseInt('0' + util.getValue(lines,'cyclecount', '='), 10);
@@ -123,7 +127,7 @@ module.exports = function (callback) {
         });
       }
       if (_windows) {
-        exec(util.getWmic() + ' Path Win32_Battery Get BatteryStatus, DesignCapacity, EstimatedChargeRemaining /value', function (error, stdout) {
+        exec(util.getWmic() + ' Path Win32_Battery Get BatteryStatus, DesignCapacity, EstimatedChargeRemaining /value', opts, function (error, stdout) {
           if (stdout) {
             let lines = stdout.split('\r\n');
             let status = util.getValue(lines, 'BatteryStatus', '=').trim();

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -113,6 +113,10 @@ const AMDBaseFrequencies = {
   '7351P': '2.4'
 };
 
+const opts = {
+  windowsHide: true
+};
+
 function cpuBrandManufacturer(res) {
   res.brand = res.brand.replace(/\(R\)+/g, '®');
   res.brand = res.brand.replace(/\(TM\)+/g, '™');
@@ -170,7 +174,7 @@ function getCpu() {
         cache: {}
       };
       if (_darwin) {
-        exec('sysctl machdep.cpu hw.cpufrequency_max hw.cpufrequency_min', function (error, stdout) {
+        exec('sysctl machdep.cpu hw.cpufrequency_max hw.cpufrequency_min', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             const modelline = util.getValue(lines, 'machdep.cpu.brand_string');
@@ -197,7 +201,7 @@ function getCpu() {
         let modelline = '';
         let lines = [];
         if (os.cpus()[0] && os.cpus()[0].model) modelline = os.cpus()[0].model;
-        exec('export LC_ALL=C; lscpu; unset LC_ALL', function (error, stdout) {
+        exec('export LC_ALL=C; lscpu; unset LC_ALL', opts, function (error, stdout) {
           if (!error) {
             lines = stdout.toString().split('\n');
           }
@@ -241,7 +245,7 @@ function getCpu() {
         let modelline = '';
         let lines = [];
         if (os.cpus()[0] && os.cpus()[0].model) modelline = os.cpus()[0].model;
-        exec('export LC_ALL=C; dmidecode -t 4; dmidecode -t 7 ; unset LC_ALL', function (error, stdout) {
+        exec('export LC_ALL=C; dmidecode -t 4; dmidecode -t 7 ; unset LC_ALL', opts, function (error, stdout) {
           let cache = [];
           if (!error) {
             const data = stdout.toString().split('# dmidecode');
@@ -298,7 +302,7 @@ function getCpu() {
         });
       }
       if (_windows) {
-        exec(util.getWmic() + ' cpu get name, description, revision, l2cachesize, l3cachesize, manufacturer, currentclockspeed, maxclockspeed /value', function (error, stdout) {
+        exec(util.getWmic() + ' cpu get name, description, revision, l2cachesize, l3cachesize, manufacturer, currentclockspeed, maxclockspeed /value', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n');
             let name = util.getValue(lines, 'name', '=') || '';
@@ -342,7 +346,7 @@ function getCpu() {
               }
             }
           }
-          exec(util.getWmic() + ' path Win32_CacheMemory get CacheType,InstalledSize,Purpose', function (error, stdout) {
+          exec(util.getWmic() + ' path Win32_CacheMemory get CacheType,InstalledSize,Purpose', opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
               lines.forEach(function (line) {
@@ -446,7 +450,7 @@ function cpuTemperature(callback) {
         max: -1.0
       };
       if (_linux) {
-        exec('sensors', function (error, stdout) {
+        exec('sensors', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             lines.forEach(function (line) {
@@ -468,7 +472,7 @@ function cpuTemperature(callback) {
           } else {
             fs.stat('/sys/class/thermal/thermal_zone0/temp', function(err) {
               if(err === null) {
-                exec('cat /sys/class/thermal/thermal_zone0/temp', function (error, stdout) {
+                exec('cat /sys/class/thermal/thermal_zone0/temp', opts, function (error, stdout) {
                   if (!error) {
                     let lines = stdout.toString().split('\n');
                     if (lines.length > 0) {
@@ -480,7 +484,7 @@ function cpuTemperature(callback) {
                   resolve(result);
                 });
               } else {
-                exec('/opt/vc/bin/vcgencmd measure_temp', function (error, stdout) {
+                exec('/opt/vc/bin/vcgencmd measure_temp', opts, function (error, stdout) {
                   if (!error) {
                     let lines = stdout.toString().split('\n');
                     if (lines.length > 0 && lines[0].indexOf('=')) {
@@ -498,7 +502,7 @@ function cpuTemperature(callback) {
         });
       }
       if (_freebsd || _openbsd) {
-        exec('sysctl dev.cpu | grep temp', function (error, stdout) {
+        exec('sysctl dev.cpu | grep temp', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             let sum = 0;
@@ -534,7 +538,7 @@ function cpuTemperature(callback) {
         resolve(result);
       }
       if (_windows) {
-        exec(util.getWmic() + ' /namespace:\\\\root\\wmi PATH MSAcpi_ThermalZoneTemperature get CurrentTemperature', function (error, stdout) {
+        exec(util.getWmic() + ' /namespace:\\\\root\\wmi PATH MSAcpi_ThermalZoneTemperature get CurrentTemperature', opts, function (error, stdout) {
           if (!error) {
             let sum = 0;
             let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
@@ -567,7 +571,7 @@ function cpuFlags(callback) {
     process.nextTick(() => {
       let result = '';
       if (_windows) {
-        exec('reg query "HKEY_LOCAL_MACHINE\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" /v FeatureSet', function (error, stdout) {
+        exec('reg query "HKEY_LOCAL_MACHINE\\HARDWARE\\DESCRIPTION\\System\\CentralProcessor\\0" /v FeatureSet', opts, function (error, stdout) {
           if (!error) {
             let flag_hex = stdout.split('0x').pop().trim();
             let flag_bin_unpadded = parseInt(flag_hex, 16).toString(2);
@@ -592,7 +596,7 @@ function cpuFlags(callback) {
         });
       }
       if (_linux) {
-        exec('lscpu', function (error, stdout) {
+        exec('lscpu', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             lines.forEach(function (line) {
@@ -606,7 +610,7 @@ function cpuFlags(callback) {
         });
       }
       if (_freebsd || _openbsd) {
-        exec('export LC_ALL=C; dmidecode -t 4; unset LC_ALL', function (error, stdout) {
+        exec('export LC_ALL=C; dmidecode -t 4; unset LC_ALL', opts, function (error, stdout) {
           let flags = [];
           if (!error) {
             let parts = stdout.toString().split('\tFlags:');
@@ -624,7 +628,7 @@ function cpuFlags(callback) {
         });
       }
       if (_darwin) {
-        exec('sysctl machdep.cpu.features', function (error, stdout) {
+        exec('sysctl machdep.cpu.features', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             if (lines.length > 0 && lines[0].indexOf('machdep.cpu.features:') !== -1) {
@@ -656,7 +660,7 @@ function cpuCache(callback) {
         l3: -1,
       };
       if (_linux) {
-        exec('lscpu', function (error, stdout) {
+        exec('lscpu', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             lines.forEach(function (line) {
@@ -680,7 +684,7 @@ function cpuCache(callback) {
         });
       }
       if (_freebsd || _openbsd) {
-        exec('export LC_ALL=C; dmidecode -t 7 ; unset LC_ALL', function (error, stdout) {
+        exec('export LC_ALL=C; dmidecode -t 7 ; unset LC_ALL', opts, function (error, stdout) {
           let cache = [];
           if (!error) {
             const data = stdout.toString();
@@ -709,7 +713,7 @@ function cpuCache(callback) {
         });
       }
       if (_darwin) {
-        exec('sysctl hw.l1icachesize hw.l1dcachesize hw.l2cachesize hw.l3cachesize', function (error, stdout) {
+        exec('sysctl hw.l1icachesize hw.l1dcachesize hw.l2cachesize hw.l3cachesize', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             lines.forEach(function (line) {
@@ -733,7 +737,7 @@ function cpuCache(callback) {
         });
       }
       if (_windows) {
-        exec(util.getWmic() + ' cpu get l2cachesize, l3cachesize /value', function (error, stdout) {
+        exec(util.getWmic() + ' cpu get l2cachesize, l3cachesize /value', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n');
             result.l1d = 0;
@@ -743,7 +747,7 @@ function cpuCache(callback) {
             if (result.l2) { result.l2 = parseInt(result.l2) * 1024; }
             if (result.l3) { result.l3 = parseInt(result.l3) * 1024; }
           }
-          exec(util.getWmic() + ' path Win32_CacheMemory get CacheType,InstalledSize,Purpose', function (error, stdout) {
+          exec(util.getWmic() + ' path Win32_CacheMemory get CacheType,InstalledSize,Purpose', opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
               lines.forEach(function (line) {

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -29,6 +29,10 @@ const NOT_SUPPORTED = 'not supported';
 let _fs_speed = {};
 let _disk_io = {};
 
+const opts = {
+  windowsHide: true
+};
+
 // --------------------------
 // FS - mounted file systems
 
@@ -42,7 +46,7 @@ function fsSize(callback) {
         if (_darwin) cmd = 'df -lkP | grep ^/';
         if (_linux) cmd = 'df -lkPT | grep ^/';
         if (_freebsd || _openbsd) cmd = 'df -lkPT';
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             //lines.splice(0, 1);
@@ -69,7 +73,7 @@ function fsSize(callback) {
         });
       }
       if (_windows) {
-        exec(util.getWmic() + ' logicaldisk get Caption,FileSystem,FreeSpace,Size', function (error, stdout) {
+        exec(util.getWmic() + ' logicaldisk get Caption,FileSystem,FreeSpace,Size', opts, function (error, stdout) {
           let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
           lines.forEach(function (line) {
             if (line !== '') {
@@ -208,7 +212,7 @@ function blockDevices(callback) {
       if (_linux) {
         // see https://wiki.ubuntuusers.de/lsblk/
         // exec("lsblk -bo NAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,UUID,ROTA,RO,TRAN,SERIAL,LABEL,MODEL,OWNER,GROUP,MODE,ALIGNMENT,MIN-IO,OPT-IO,PHY-SEC,LOG-SEC,SCHED,RQ-SIZE,RA,WSAME", function (error, stdout) {
-        exec('lsblk -bPo NAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,UUID,ROTA,RO,RM,TRAN,SERIAL,LABEL,MODEL,OWNER', function (error, stdout) {
+        exec('lsblk -bPo NAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,UUID,ROTA,RO,RM,TRAN,SERIAL,LABEL,MODEL,OWNER', opts, function (error, stdout) {
           if (!error) {
             let lines = blkStdoutToObject(stdout).split('\n');
             data = parseBlk(lines);
@@ -217,7 +221,7 @@ function blockDevices(callback) {
             }
             resolve(data);
           } else {
-            exec('lsblk -bPo NAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,UUID,ROTA,RO,RM,LABEL,MODEL,OWNER', function (error, stdout) {
+            exec('lsblk -bPo NAME,TYPE,SIZE,FSTYPE,MOUNTPOINT,UUID,ROTA,RO,RM,LABEL,MODEL,OWNER', opts, function (error, stdout) {
               if (!error) {
                 let lines = blkStdoutToObject(stdout).split('\n');
                 data = parseBlk(lines);
@@ -231,7 +235,7 @@ function blockDevices(callback) {
         });
       }
       if (_darwin) {
-        exec('diskutil info -all', function (error, stdout) {
+        exec('diskutil info -all', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             // parse lines into temp array of devices
@@ -245,7 +249,7 @@ function blockDevices(callback) {
       }
       if (_windows) {
         let drivetypes = ['Unknown', 'NoRoot', 'Removable', 'HDD', 'Network', 'CD/DVD', 'RAM'];
-        exec(util.getWmic() + ' logicaldisk get Caption,Description,DeviceID,DriveType,FileSystem,FreeSpace,Name,Size,VolumeName,VolumeSerialNumber /value', function (error, stdout) {
+        exec(util.getWmic() + ' logicaldisk get Caption,Description,DeviceID,DriveType,FileSystem,FreeSpace,Name,Size,VolumeName,VolumeSerialNumber /value', opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split(/\n\s*\n/);
             devices.forEach(function (device) {
@@ -355,7 +359,7 @@ function fsStats(callback) {
       if ((_fs_speed && !_fs_speed.ms) || (_fs_speed && _fs_speed.ms && Date.now() - _fs_speed.ms >= 500)) {
         if (_linux) {
           // exec("df -k | grep /dev/", function(error, stdout) {
-          exec('lsblk | grep /', function (error, stdout) {
+          exec('lsblk | grep /', opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               let fs_filter = [];
@@ -367,7 +371,7 @@ function fsStats(callback) {
               });
 
               let output = fs_filter.join('|');
-              exec('cat /proc/diskstats | egrep "' + output + '"', function (error, stdout) {
+              exec('cat /proc/diskstats | egrep "' + output + '"', opts, function (error, stdout) {
                 if (!error) {
                   let lines = stdout.toString().split('\n');
                   lines.forEach(function (line) {
@@ -395,7 +399,7 @@ function fsStats(callback) {
           });
         }
         if (_darwin) {
-          exec("ioreg -c IOBlockStorageDriver -k Statistics -r -w0 | sed -n '/IOBlockStorageDriver/,/Statistics/p' | grep 'Statistics' | tr -cd '01234567890,\n' | awk -F',' '{print $3, $10}'", function (error, stdout) {
+          exec("ioreg -c IOBlockStorageDriver -k Statistics -r -w0 | sed -n '/IOBlockStorageDriver/,/Statistics/p' | grep 'Statistics' | tr -cd '01234567890,\n' | awk -F',' '{print $3, $10}'", opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               lines.forEach(function (line) {
@@ -505,7 +509,7 @@ function disksIO(callback) {
           // var cmd = "for mount in `lsblk | grep / | sed 's/[│└─├]//g' | awk '{$1=$1};1' | cut -d ' ' -f 1 | sort -u`; do cat /sys/block/$mount/stat | sed -r 's/ +/;/g' | sed -r 's/^;//'; done";
           let cmd = "for mount in `lsblk | grep ' disk ' | sed 's/[│└─├]//g' | awk '{$1=$1};1' | cut -d ' ' -f 1 | sort -u`; do cat /sys/block/$mount/stat | sed -r 's/ +/;/g' | sed -r 's/^;//'; done";
 
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.split('\n');
               lines.forEach(function (line) {
@@ -532,7 +536,7 @@ function disksIO(callback) {
           });
         }
         if (_darwin) {
-          exec("ioreg -c IOBlockStorageDriver -k Statistics -r -w0 | sed -n '/IOBlockStorageDriver/,/Statistics/p' | grep 'Statistics' | tr -cd '01234567890,\n' | awk -F',' '{print $1, $11}'", function (error, stdout) {
+          exec("ioreg -c IOBlockStorageDriver -k Statistics -r -w0 | sed -n '/IOBlockStorageDriver/,/Statistics/p' | grep 'Statistics' | tr -cd '01234567890,\n' | awk -F',' '{print $1, $11}'", opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               lines.forEach(function (line) {
@@ -579,7 +583,7 @@ function diskLayout(callback) {
       let result = [];
 
       if (_linux) {
-        exec('export LC_ALL=C; lshw -class disk; unset LC_ALL', function (error, stdout) {
+        exec('export LC_ALL=C; lshw -class disk; unset LC_ALL', opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('*-');
             devices.shift();
@@ -588,7 +592,7 @@ function diskLayout(callback) {
               let mediumType = '';
               const logical = util.getValue(lines, 'logical name', ':', true).trim().replace(/\/dev\//g, '');
               try {
-                mediumType = execSync('cat /sys/block/' + logical + '/queue/rotational').toString().split('\n')[0];
+                mediumType = execSync('cat /sys/block/' + logical + '/queue/rotational', opts).toString().split('\n')[0];
               } catch (e) {
                 util.noop();
               }
@@ -627,7 +631,7 @@ function diskLayout(callback) {
       }      
 
       if (_darwin) {
-        exec('system_profiler SPSerialATADataType SPNVMeDataType', function (error, stdout) {
+        exec('system_profiler SPSerialATADataType SPNVMeDataType', opts, function (error, stdout) {
           if (!error) {
             let parts = stdout.toString().split('NVMExpress:');
 
@@ -712,7 +716,7 @@ function diskLayout(callback) {
       }
       if (_windows) {
 
-        exec(util.getWmic() + ' diskdrive get /value', {encoding: 'utf8'}, function (error, stdout) {
+        exec(util.getWmic() + ' diskdrive get /value', {encoding: 'utf8'}, opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split(/\n\s*\n/);
             devices.forEach(function (device) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -27,6 +27,10 @@ let _resolutionx = 0;
 let _resolutiony = 0;
 let _pixeldepth = 0;
 
+const opts = {
+  windowsHide: true
+};
+
 function toInt(value) {
   let result = parseInt(value, 10);
   if (isNaN(result)) {
@@ -284,7 +288,7 @@ function graphics(callback) {
       };
       if (_darwin) {
         let cmd = 'system_profiler SPDisplaysDataType';
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result = parseLinesDarwin(lines);
@@ -297,20 +301,20 @@ function graphics(callback) {
       }
       if (_linux) {
         let cmd = 'lspci -vvv  2>/dev/null';
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result.controllers = parseLinesLinuxControllers(lines);
           }
           let cmd = "xdpyinfo 2>/dev/null | grep 'depth of root window' | awk '{ print $5 }'";
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             let depth = 0;
             if (!error) {
               let lines = stdout.toString().split('\n');
               depth = parseInt(lines[0]) || 0;
             }
             let cmd = 'xrandr --verbose 2>/dev/null';
-            exec(cmd, function (error, stdout) {
+            exec(cmd, opts, function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().split('\n');
                 result.displays = parseLinesLinuxDisplays(lines, depth);
@@ -329,11 +333,11 @@ function graphics(callback) {
       }      
       if (_windows) {
         // https://blogs.technet.microsoft.com/heyscriptingguy/2013/10/03/use-powershell-to-discover-multi-monitor-information/
-        exec(util.getWmic() + ' path win32_VideoController get AdapterCompatibility, AdapterDACType, name, PNPDeviceID, CurrentVerticalResolution, CurrentHorizontalResolution, CurrentNumberOfColors, AdapterRAM, CurrentBitsPerPixel, CurrentRefreshRate, MinRefreshRate, MaxRefreshRate, VideoMemoryType /value', function (error, stdout) {
+        exec(util.getWmic() + ' path win32_VideoController get AdapterCompatibility, AdapterDACType, name, PNPDeviceID, CurrentVerticalResolution, CurrentHorizontalResolution, CurrentNumberOfColors, AdapterRAM, CurrentBitsPerPixel, CurrentRefreshRate, MinRefreshRate, MaxRefreshRate, VideoMemoryType /value', opts, function (error, stdout) {
           if (!error) {
             let csections = stdout.split(/\n\s*\n/);
             result.controllers = parseLinesWindowsControllers(csections);
-            exec(util.getWmic() + ' path win32_desktopmonitor get Caption, MonitorManufacturer, MonitorType, ScreenWidth, ScreenHeight /value', function (error, stdout) {
+            exec(util.getWmic() + ' path win32_desktopmonitor get Caption, MonitorManufacturer, MonitorType, ScreenWidth, ScreenHeight /value', opts, function (error, stdout) {
               let dsections = stdout.split(/\n\s*\n/);
               if (!error) {
                 result.displays = parseLinesWindowsDisplays(dsections);

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -23,6 +23,10 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
+const opts = {
+  windowsHide: true
+};
+
 // --------------------------
 // check if external site is available
 
@@ -43,7 +47,7 @@ function inetChecksite(url, callback) {
         if (_linux || _freebsd || _openbsd || _darwin) {
           let args = ' -I --connect-timeout 5 -m 5 ' + url + ' 2>/dev/null | head -n 1 | cut -d " " -f2';
           let cmd = 'curl';
-          exec(cmd + args, function (error, stdout) {
+          exec(cmd + args, opts, function (error, stdout) {
             let statusCode = parseInt(stdout.toString());
             result.status = statusCode || 404;
             result.ok = !error && (statusCode === 200 || statusCode === 301 || statusCode === 302 || statusCode === 304);
@@ -120,7 +124,7 @@ function inetLatency(host, callback) {
           cmd = 'ping -c 2 -t 3 ' + host + ' | grep avg';
         }
 
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           let result = -1;
           if (!error) {
             const line = stdout.toString().split('=');
@@ -136,7 +140,7 @@ function inetLatency(host, callback) {
         });
       }
       if (_windows) {
-        exec('ping ' + host + ' -n 1', function (error, stdout) {
+        exec('ping ' + host + ' -n 1', opts, function (error, stdout) {
           let result = -1;
           if (!error) {
             let lines = stdout.toString().split('\r\n');

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -39,6 +39,10 @@ const OSX_RAM_manufacturers = {
   '0x859B': 'Crucial'
 };
 
+const opts = {
+  windowsHide: true
+};
+
 // _______________________________________________________________________________________
 // |                         R A M                              |          H D           |
 // |______________________|_________________________|           |                        |
@@ -109,7 +113,7 @@ function mem(callback) {
       };
 
       if (_linux) {
-        exec('free -b', function (error, stdout) {
+        exec('free -b', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
 
@@ -138,7 +142,7 @@ function mem(callback) {
         });
       }
       if (_freebsd || _openbsd) {
-        exec('/sbin/sysctl -a | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', function (error, stdout) {
+        exec('/sbin/sysctl -a | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             const pagesize = parseInt(util.getValue(lines, 'vm.stats.vm.v_page_size'), 10);
@@ -162,7 +166,7 @@ function mem(callback) {
         });
       }
       if (_darwin) {
-        exec('vm_stat | grep "Pages active"', function (error, stdout) {
+        exec('vm_stat | grep "Pages active"', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
 
@@ -170,7 +174,7 @@ function mem(callback) {
             result.buffcache = result.used - result.active;
             result.available = result.free + result.buffcache;
           }
-          exec('sysctl -n vm.swapusage', function (error, stdout) {
+          exec('sysctl -n vm.swapusage', opts, function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               if (lines.length > 0) {
@@ -191,7 +195,7 @@ function mem(callback) {
       if (_windows) {
         let swaptotal = 0;
         let swapused = 0;
-        exec(util.getWmic() + ' pagefile get AllocatedBaseSize, CurrentUsage', function (error, stdout) {
+        exec(util.getWmic() + ' pagefile get AllocatedBaseSize, CurrentUsage', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0);
             lines.forEach(function (line) {
@@ -231,7 +235,7 @@ function memLayout(callback) {
       let result = [];
 
       if (_linux || _freebsd || _openbsd) {
-        exec('dmidecode -t memory | grep -iE "Size:|Type|Speed|Manufacturer|Form Factor|Locator|Memory Device|Serial Number|Voltage|Part Number"', function (error, stdout) {
+        exec('dmidecode -t memory | grep -iE "Size:|Type|Speed|Manufacturer|Form Factor|Locator|Memory Device|Serial Number|Voltage|Part Number"', opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('Memory Device');
             devices.shift();
@@ -273,7 +277,7 @@ function memLayout(callback) {
       }
 
       if (_darwin) {
-        exec('system_profiler SPMemoryDataType', function (error, stdout) {
+        exec('system_profiler SPMemoryDataType', opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('        BANK ');
             devices.shift();
@@ -320,7 +324,7 @@ function memLayout(callback) {
         const memoryTypes = 'Unknown|Other|DRAM|Synchronous DRAM|Cache DRAM|EDO|EDRAM|VRAM|SRAM|RAM|ROM|FLASH|EEPROM|FEPROM|EPROM|CDRAM|3DRAM|SDRAM|SGRAM|RDRAM|DDR|DDR2|DDR2 FB-DIMM|Reserved|DDR3|FBD2|DDR4|LPDDR|LPDDR2|LPDDR3|LPDDR4'.split('|');
         const FormFactors = 'Unknown|Other|SIP|DIP|ZIP|SOJ|Proprietary|SIMM|DIMM|TSOP|PGA|RIMM|SODIMM|SRIMM|SMD|SSMP|QFP|TQFP|SOIC|LCC|PLCC|BGA|FPBGA|LGA'.split('|');
 
-        exec(util.getWmic() + ' memorychip get BankLabel, Capacity, ConfiguredClockSpeed, ConfiguredVoltage, MaxVoltage, MinVoltage, DataWidth, FormFactor, Manufacturer, MemoryType, PartNumber, SerialNumber, Speed, Tag /value', function (error, stdout) {
+        exec(util.getWmic() + ' memorychip get BankLabel, Capacity, ConfiguredClockSpeed, ConfiguredVoltage, MaxVoltage, MinVoltage, DataWidth, FormFactor, Manufacturer, MemoryType, PartNumber, SerialNumber, Speed, Tag /value', opts, function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('BankL');
             devices.shift();

--- a/lib/network.js
+++ b/lib/network.js
@@ -30,6 +30,10 @@ let _network = {};
 let _default_iface;
 let _mac = {};
 
+const opts = {
+  windowsHide: true
+};
+
 function getDefaultNetworkInterface() {
 
   if (!_default_iface) {
@@ -40,7 +44,7 @@ function getDefaultNetworkInterface() {
       if (_linux)  cmd =  'route 2>/dev/null | grep default | awk "{print $8}"';
       if (_darwin) cmd = 'route get 0.0.0.0 2>/dev/null | grep interface: | awk "{print $2}"';
       if (_freebsd || _openbsd) cmd = 'route get 0.0.0.0 | grep interface:';
-      let result = execSync(cmd);
+      let result = execSync(cmd, opts);
       ifacename = result.toString().split('\n')[0];
       if (ifacename.indexOf(':') > -1) {
         ifacename = ifacename.split(':')[1].trim();
@@ -75,7 +79,7 @@ function getMacAddresses() {
   let result = {};
   if (_linux || _freebsd || _openbsd) {
     const cmd = 'export LC_ALL=C; /sbin/ifconfig; unset LC_ALL';
-    let res = execSync(cmd);
+    let res = execSync(cmd, opts);
     const lines = res.toString().split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (lines[i] && lines[i][0] !== ' ') {
@@ -92,7 +96,7 @@ function getMacAddresses() {
   }
   if (_darwin) {
     const cmd = '/sbin/ifconfig';
-    let res = execSync(cmd);
+    let res = execSync(cmd, opts);
     const lines = res.toString().split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (lines[i] && lines[i][0] !== '\t' && lines[i].indexOf(':') > 0) {
@@ -281,7 +285,7 @@ function networkStats(iface, callback) {
               'cat /sys/class/net/' + iface + '/operstate; ' +
               'cat /sys/class/net/' + iface + '/statistics/rx_bytes; ' +
               'cat /sys/class/net/' + iface + '/statistics/tx_bytes; ';
-            exec(cmd, function (error, stdout) {
+            exec(cmd, opts, function (error, stdout) {
               if (!error) {
                 lines = stdout.toString().split('\n');
                 operstate = lines[0].trim();
@@ -301,7 +305,7 @@ function networkStats(iface, callback) {
         }
         if (_freebsd || _openbsd) {
           cmd = 'netstat -ibnI ' + iface;
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             if (!error) {
               lines = stdout.toString().split('\n');
               for (let i = 1; i < lines.length; i++) {
@@ -320,12 +324,12 @@ function networkStats(iface, callback) {
         }
         if (_darwin) {
           cmd = 'ifconfig ' + iface + ' | grep "status"';
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             result.operstate = (stdout.toString().split(':')[1] || '').trim();
             result.operstate = (result.operstate || '').toLowerCase();
             result.operstate = (result.operstate === 'active' ? 'up' : (result.operstate === 'inactive' ? 'down' : 'unknown'));
             cmd = 'netstat -bI ' + iface;
-            exec(cmd, function (error, stdout) {
+            exec(cmd, opts, function (error, stdout) {
               if (!error) {
                 lines = stdout.toString().split('\n');
                 // if there is less than 2 lines, no information for this interface was found
@@ -349,14 +353,14 @@ function networkStats(iface, callback) {
           let perfData = [];
           let nics = [];
           cmd = util.getWmic() + ' nic get MACAddress, name, NetEnabled /value';
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             if (!error) {
               const nsections = stdout.split(/\n\s*\n/);
               nics = parseLinesWindowsNics(nsections);
 
               // Performance Data
               cmd = util.getWmic() + ' path Win32_PerfRawData_Tcpip_NetworkInterface Get name,BytesReceivedPersec,BytesSentPersec,BytesTotalPersec /value';
-              exec(cmd, function (error, stdout) {
+              exec(cmd, opts, function (error, stdout) {
                 if (!error) {
                   const psections = stdout.split(/\n\s*\n/);
                   perfData = parseLinesWindowsPerfData(psections);
@@ -428,7 +432,7 @@ function networkConnections(callback) {
       if (_linux || _freebsd || _openbsd) {
         let cmd = 'netstat -tuna | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN\\|VERBUNDEN"';
         if (_freebsd || _openbsd) cmd = 'netstat -na | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN\\|VERBUNDEN"'
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             lines.forEach(function (line) {
@@ -470,7 +474,7 @@ function networkConnections(callback) {
             resolve(result);
           } else {
             cmd = 'ss -tuna | grep "ESTAB\\|SYN-SENT\\|SYN-RECV\\|FIN-WAIT1\\|FIN-WAIT2\\|TIME-WAIT\\|CLOSE\\|CLOSE-WAIT\\|LAST-ACK\\|LISTEN\\|CLOSING"';
-            exec(cmd, function (error, stdout) {
+            exec(cmd, opts, function (error, stdout) {
 
               if (!error) {
                 let lines = stdout.toString().split('\n');
@@ -519,7 +523,7 @@ function networkConnections(callback) {
       }
       if (_darwin) {
         let cmd = 'netstat -nat | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN"';
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
 
             let lines = stdout.toString().split('\n');
@@ -565,7 +569,7 @@ function networkConnections(callback) {
       }
       if (_windows) {
         let cmd = 'netstat -na';
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
 
             let lines = stdout.toString().split('\r\n');

--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -26,6 +26,10 @@ const _openbsd = (_platform === 'openbsd');
 
 const NOT_SUPPORTED = 'not supported';
 
+const opts = {
+  windowsHide: true
+};
+
 // --------------------------
 // Get current time and OS uptime
 
@@ -163,7 +167,7 @@ function osInfo(callback) {
 
       if (_linux) {
 
-        exec('cat /etc/*-release', function (error, stdout) {
+        exec('cat /etc/*-release', opts, function (error, stdout) {
           //if (!error) {
           /**
            * @namespace
@@ -193,7 +197,7 @@ function osInfo(callback) {
       }
       if (_freebsd || _openbsd) {
 
-        exec('sysctl kern.ostype kern.osrelease kern.osrevision', function (error, stdout) {
+        exec('sysctl kern.ostype kern.osrelease kern.osrevision', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result.distro = util.getValue(lines, 'kern.ostype');
@@ -208,7 +212,7 @@ function osInfo(callback) {
         });
       }
       if (_darwin) {
-        exec('sw_vers', function (error, stdout) {
+        exec('sw_vers', opts, function (error, stdout) {
           let lines = stdout.toString().split('\n');
           lines.forEach(function (line) {
             if (line.indexOf('ProductName') !== -1) {
@@ -226,7 +230,7 @@ function osInfo(callback) {
       if (_windows) {
         result.logofile = getLogoFile();
         result.release = result.kernel;
-        exec(util.getWmic() + ' os get Caption', function (error, stdout) {
+        exec(util.getWmic() + ' os get Caption', opts, function (error, stdout) {
           result.distro = result.codename = stdout.slice(stdout.indexOf('\r\n') + 2).trim();
           if (callback) {
             callback(result);
@@ -257,37 +261,37 @@ function versions(callback) {
         tsc: '',
       };
       let parts = [];
-      exec('npm -v', function (error, stdout) {
+      exec('npm -v', opts, function (error, stdout) {
         if (!error) {
           result.npm = stdout.toString().split('\n')[0];
         }
-        exec('pm2 -v', function (error, stdout) {
+        exec('pm2 -v', opts, function (error, stdout) {
           if (!error) {
             parts = stdout.toString().split('\n');
             if (parts.length >= 2) {
               result.pm2 = parts[parts.length - 2];
             }
           }
-          exec('yarn --version', function (error, stdout) {
+          exec('yarn --version', opts, function (error, stdout) {
             if (!error) {
               result.yarn = stdout.toString().split('\n')[0];
             }
-            exec('gulp --version', function (error, stdout) {
+            exec('gulp --version', opts, function (error, stdout) {
               if (!error) {
                 result.gulp = stdout.toString().split('\n')[0] || '';
                 result.gulp = (result.gulp.toLowerCase().split('version')[1] || '').trim();
               }
-              exec('tsc --version', function (error, stdout) {
+              exec('tsc --version', opts, function (error, stdout) {
                 if (!error) {
                   result.tsc = stdout.toString().split('\n')[0] || '';
                   result.tsc = (result.tsc.toLowerCase().split('version')[1] || '').trim();
                 }
-                exec('grunt --version', function (error, stdout) {
+                exec('grunt --version', opts, function (error, stdout) {
                   if (!error) {
                     result.grunt = stdout.toString().split('\n')[0] || '';
                     result.grunt = (result.grunt.toLowerCase().split('cli v')[1] || '').trim();
                   }
-                  exec('git --version', function (error, stdout) {
+                  exec('git --version', opts, function (error, stdout) {
                     if (!error) {
                       result.git = stdout.toString().split('\n')[0] || '';
                       result.git = (result.git.toLowerCase().split('version')[1] || '').trim();
@@ -322,7 +326,7 @@ function shell(callback) {
       }
 
       let result = '';
-      exec('echo $SHELL', function (error, stdout) {
+      exec('echo $SHELL', opts, function (error, stdout) {
         if (!error) {
           result = stdout.toString().split('\n')[0];
         }

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -46,6 +46,9 @@ let _winStatusValues = {
   '9': 'growing',
 };
 
+const opts = {
+  windowsHide: true
+};
 
 function parseTimeWin(time) {
   time = time || '';
@@ -81,7 +84,7 @@ function services(srv, callback) {
         if (_linux || _freebsd || _openbsd || _darwin) {
           let comm = (_darwin) ? 'ps -caxm -o pcpu,pmem,comm' : 'ps axo pcpu,pmem,comm';
           if (srv !== '' && srvs.length > 0) {
-            exec(comm + " | grep -v grep | egrep '" + srv + "'", function (error, stdout) {
+            exec(comm + " | grep -v grep | egrep '" + srv + "'", opts, function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().replace(/ +/g, ' ').replace(/,+/g, '.').split('\n');
                 srvs.forEach(function (srv) {
@@ -120,7 +123,7 @@ function services(srv, callback) {
           }
         }
         if (_windows) {
-          exec(util.getWmic() + ' service get /value', {maxBuffer: 1024 * 1000}, function (error, stdout) {
+          exec(util.getWmic() + ' service get /value', {maxBuffer: 1024 * 1000, windowsHide: true}, function (error, stdout) {
             if (!error) {
               let serviceSections = stdout.split(/\n\s*\n/);
               for (let i = 0; i < serviceSections.length; i++) {
@@ -419,7 +422,7 @@ function processes(callback) {
           if (_linux) cmd = 'ps axo pid:10,pcpu:6,pmem:6,pri:5,vsz:10,rss:10,ni:5,start:20,state:20,tty:20,user:20,command';
           if (_freebsd || _openbsd) cmd = 'ps axo pid,pcpu,pmem,pri,vsz,rss,ni,start,state,tty,user,command';
           if (_darwin) cmd = 'ps acxo pid,pcpu,pmem,pri,vsz,rss,nice,start,state,tty,user,command -r';
-          exec(cmd, function (error, stdout) {
+          exec(cmd, opts, function (error, stdout) {
             if (!error) {
               result.list = parseProcesses(stdout.toString().split('\n'));
               result.all = result.list.length;
@@ -439,7 +442,7 @@ function processes(callback) {
                 for (let i = 0; i < result.list.length; i++) {
                   cmd += (';cat /proc/' + result.list[i].pid + '/stat');
                 }
-                exec(cmd, function (error, stdout) {
+                exec(cmd, opts, function (error, stdout) {
                   let curr_processes = stdout.toString().split('\n');
 
                   // first line (all - /proc/stat)
@@ -489,7 +492,7 @@ function processes(callback) {
           });
         }
         if (_windows) {
-          exec(util.getWmic() + ' process get /value', {maxBuffer: 1024 * 1000}, function (error, stdout) {
+          exec(util.getWmic() + ' process get /value', {maxBuffer: 1024 * 1000, windowsHide: true}, function (error, stdout) {
             if (!error) {
               let processSections = stdout.split(/\n\s*\n/);
               let procs = [];
@@ -613,7 +616,7 @@ function processLoad(proc, callback) {
       };
 
       if (proc) {
-        exec('ps aux | grep ' + proc + ' | grep -v grep', function (error, stdout) {
+        exec('ps aux | grep ' + proc + ' | grep -v grep', opts, function (error, stdout) {
           if (!error) {
             let data = stdout.replace(/ +/g, ' ').split(' ');
 

--- a/lib/system.js
+++ b/lib/system.js
@@ -24,6 +24,10 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
+const opts = {
+  windowsHide: true
+};
+
 function system(callback) {
 
   return new Promise((resolve) => {
@@ -39,7 +43,7 @@ function system(callback) {
       };
 
       if (_linux || _freebsd || _openbsd) {
-        exec('dmidecode -t system', function (error, stdout) {
+        exec('dmidecode -t system', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result.manufacturer = util.getValue(lines, 'manufacturer');
@@ -56,7 +60,7 @@ function system(callback) {
             
             if (result.manufacturer === '' && result.model === 'Computer' && result.version === '-') {
               // Check Raspberry Pi
-              exec('grep Hardware /proc/cpuinfo; grep Serial /proc/cpuinfo; grep Revision /proc/cpuinfo', function (error, stdout) {
+              exec('grep Hardware /proc/cpuinfo; grep Serial /proc/cpuinfo; grep Revision /proc/cpuinfo', opts, function (error, stdout) {
                 if (!error) {
                   let lines = stdout.toString().split('\n');
                   lines.forEach(function (line) {
@@ -129,7 +133,7 @@ function system(callback) {
               resolve(result);
             }
           } else {
-            exec('dmesg | grep -i virtual | grep -iE "vmware|qemu|kvm|xen"', function (error, stdout) {
+            exec('dmesg | grep -i virtual | grep -iE "vmware|qemu|kvm|xen"', opts, function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().split('\n');
                 if (lines.length > 0) result.model = 'Virtual machine';
@@ -144,7 +148,7 @@ function system(callback) {
         });
       }
       if (_darwin) {
-        exec('ioreg -c IOPlatformExpertDevice -d 2', function (error, stdout) {
+        exec('ioreg -c IOPlatformExpertDevice -d 2', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().replace(/[<>"]/g, '').split('\n');
             result.manufacturer = util.getValue(lines, 'manufacturer', '=', true);
@@ -161,7 +165,7 @@ function system(callback) {
       if (_windows) {
         // exec('wmic csproduct get', function (error, stdout) {
         // ToDo: refactor /value
-        exec(util.getWmic() + ' csproduct get /value', function (error, stdout) {
+        exec(util.getWmic() + ' csproduct get /value', opts, function (error, stdout) {
           if (!error) {
             // let lines = stdout.split('\r\n').filter(line => line.trim() !== '').filter((line, idx) => idx > 0)[0].trim().split(/\s\s+/);
             let lines = stdout.split('\r\n');
@@ -201,7 +205,7 @@ function bios(callback) {
         } else {
           cmd = 'dmidecode --type 0';
         }
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result.vendor = util.getValue(lines, 'Vendor');
@@ -222,7 +226,7 @@ function bios(callback) {
       }
       if (_windows) {
         // ToDo: check BIOS windows
-        exec(util.getWmic() + ' bios get /value', function (error, stdout) {
+        exec(util.getWmic() + ' bios get /value', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\r\n');
             const description = util.getValue(lines, 'description', '=');
@@ -275,7 +279,7 @@ function baseboard(callback) {
         } else {
           cmd = 'dmidecode -t 2';
         }
-        exec(cmd, function (error, stdout) {
+        exec(cmd, opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             result.manufacturer = util.getValue(lines, 'Manufacturer');
@@ -292,7 +296,7 @@ function baseboard(callback) {
         });
       }
       if (_darwin) {
-        exec('ioreg -c IOPlatformExpertDevice -d 2', function (error, stdout) {
+        exec('ioreg -c IOPlatformExpertDevice -d 2', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().replace(/[<>"]/g, '').split('\n');
             result.manufacturer = util.getValue(lines, 'manufacturer', '=', true);
@@ -308,7 +312,7 @@ function baseboard(callback) {
       }
       if (_windows) {
         // ToDo: check BIOS windows
-        exec(util.getWmic() + ' baseboard get /value', function (error, stdout) {
+        exec(util.getWmic() + ' baseboard get /value', opts, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\r\n');
 

--- a/lib/users.js
+++ b/lib/users.js
@@ -23,6 +23,10 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
+const opts = {
+  windowsHide: true
+};
+
 // --------------------------
 // array of users online = sessions
 
@@ -180,13 +184,13 @@ function users(callback) {
 
       // linux
       if (_linux) {
-        exec('who --ips; echo "---"; w | tail -n +2', function (error, stdout) {
+        exec('who --ips; echo "---"; w | tail -n +2', opts, function (error, stdout) {
           if (!error) {
             // lines / split
             let lines = stdout.toString().split('\n');
             result = parseUsersLinux(lines);
             if (result.length === 0) {
-              exec('who; echo "---"; w | tail -n +2', function (error, stdout) {
+              exec('who; echo "---"; w | tail -n +2', opts, function (error, stdout) {
                 if (!error) {
                   // lines / split
                   lines = stdout.toString().split('\n');
@@ -206,7 +210,7 @@ function users(callback) {
         });
       }
       if (_freebsd || _openbsd) {
-        exec('who; echo "---"; w -ih', function (error, stdout) {
+        exec('who; echo "---"; w -ih', opts, function (error, stdout) {
           if (!error) {
             // lines / split
             let lines = stdout.toString().split('\n');
@@ -218,7 +222,7 @@ function users(callback) {
       }
 
       if (_darwin) {
-        exec('who; echo "---"; w -ih', function (error, stdout) {
+        exec('who; echo "---"; w -ih', opts, function (error, stdout) {
           if (!error) {
             // lines / split
             let lines = stdout.toString().split('\n');
@@ -229,7 +233,7 @@ function users(callback) {
         });
       }
       if (_windows) {
-        exec('query user', function (error, stdout) {
+        exec('query user', opts, function (error, stdout) {
           if (stdout) {
             // lines / split
             let lines = stdout.toString().split('\r\n');


### PR DESCRIPTION
## Pull Request

There is no issue created

#### Changes proposed:

* [x] Fix

#### Description (what is this PR about)

On windows, `exec` create a window when a subprocess is launched.
`windowsHide: true` hide the subprocess console window that would normally be created on Windows systems. 
https://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback