### PR TITLE
[Linux/BSD][network] Add support for 'ip' instead of 'ifconfig'

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -26,9 +26,9 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
-// Check if 'ip' is available to get mac addresses on *nix. If not, use the deprecated 'ifconfig' command
+// Check if 'ip' is available to get mac addresses on linux & bsd. If not, use the deprecated 'ifconfig' command
 let isIpAvailable;
-if (_linux || _darwin || _freebsd || _openbsd) {
+if (_linux || _freebsd || _openbsd) {
   if (fs.existsSync('/sbin/ip')) {
     isIpAvailable = true;
   } else {

--- a/lib/network.js
+++ b/lib/network.js
@@ -26,6 +26,17 @@ const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
 const _openbsd = (_platform === 'openbsd');
 
+// Check if 'ip' is available to get mac addresses on *nix. If not, use the deprecated 'ifconfig' command
+let isIpAvailable;
+if (_linux || _darwin || _freebsd || _openbsd) {
+  if (fs.existsSync('/sbin/ip')) {
+    isIpAvailable = true;
+  } else {
+    isIpAvailable = false;
+  }
+}
+const macAddressCommand = (isIpAvailable) ? 'ip link show up' : 'ifconfig';
+
 const opts = {
   windowsHide: true
 };
@@ -78,13 +89,23 @@ function getMacAddresses() {
   let mac = '';
   let result = {};
   if (_linux || _freebsd || _openbsd) {
-    const cmd = 'export LC_ALL=C; /sbin/ifconfig; unset LC_ALL';
+    const cmd = 'export LC_ALL=C; /sbin/'+macAddressCommand+'; unset LC_ALL';
     let res = execSync(cmd);
     const lines = res.toString().split('\n');
     for (let i = 0; i < lines.length; i++) {
       if (lines[i] && lines[i][0] !== ' ') {
-        iface = lines[i].split(' ')[0];
-        mac = lines[i].split('HWaddr ')[1];
+        if (macAddressCommand.startsWith('ip')) {
+          let nextline = lines[i+1].trim().split(' ');
+          if (nextline[0] === 'link/ether') {
+            iface = lines[i].split(' ')[1];
+            iface = iface.slice(0, iface.length - 1);
+            mac = nextline[1];
+          }
+        } else {
+          iface = lines[i].split(' ')[0];
+          mac = lines[i].split('HWaddr ')[1];
+        }
+
         if (iface && mac) {
           result[iface] = mac.trim();
           iface = '';


### PR DESCRIPTION
## Pull Request

Fixes #114 

#### Changes proposed:

* [X] Fix
* [X] Add

#### Description (what is this PR about)

On Linux and BSD systems, prefer `ip` over `ifconfig` to find mac addresses.

**Note:** I haven't changed anything for Darwin systems, because I don't have a Mac to test on and I don't know if `ip` is distributed in MacOS anyway.

**Note 2:** I realized the commit messages and PR titles can be confusing, so, just to clarify: I kept the old code for `ifconfig` as a fallback in case `ip` isn't available.