### PR TITLE
cpuTemperature(): fix main temperature when sensors prints "Package id".

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -464,10 +464,11 @@ function cpuTemperature(callback) {
             lines.forEach(function (line) {
               let regex = /[+-]([^°]*)/g;
               let temps = line.match(regex);
-              if (line.split(':')[0].toUpperCase().indexOf('PHYSICAL') !== -1) {
+              let first = line.split(':')[0].toUpperCase();
+              if (first.indexOf('PHYSICAL') !== -1 || first.indexOf('PACKAGE') !== -1) {
                 result.main = parseFloat(temps);
               }
-              if (line.split(':')[0].toUpperCase().indexOf('CORE ') !== -1) {
+              if (first.indexOf('CORE ') !== -1) {
                 result.cores.push(parseFloat(temps));
               }
             });


### PR DESCRIPTION
## Pull Request

#### Changes proposed:

* [x] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

On Ubuntu 18.04 running on an i7-8700, "sensors" prints this output:

```
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +49.0°C  (high = +82.0°C, crit = +100.0°C)
Core 0:        +48.0°C  (high = +82.0°C, crit = +100.0°C)
Core 1:        +48.0°C  (high = +82.0°C, crit = +100.0°C)
Core 2:        +48.0°C  (high = +82.0°C, crit = +100.0°C)
Core 3:        +49.0°C  (high = +82.0°C, crit = +100.0°C)
Core 4:        +49.0°C  (high = +82.0°C, crit = +100.0°C)
Core 5:        +49.0°C  (high = +82.0°C, crit = +100.0°C)
```

Note that the main line starts with "Package id" instead of "Physical id". This PR fixes retrieval of the main temperature.
