### PR TITLE
Raspberry Pi detection fix

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -71,7 +71,7 @@ function system(callback) {
                 if (lines.length > 0) result.model = 'Virtual machine';
               }
 
-              if (result.manufacturer === '' && result.model === 'Computer' && result.version === '-') {
+              if (result.manufacturer === '' && result.model === 'Computer' && result.version === '') {
                 // Check Raspberry Pi
                 exec('cat /proc/cpuinfo', function (error, stdout) {
                   if (!error) {


### PR DESCRIPTION
## Pull Request

Fixes #

#### Changes proposed:

* [X] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

Raspberry Pi detection checks for version = '-'
Version is now an empty string so the Raspberry Pi checks are not carried out