### PR TITLE
Add timeremaining support using current and voltage on linux

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -70,6 +70,8 @@ module.exports = function (callback) {
               const percent = util.getValue(lines, 'POWER_SUPPLY_CAPACITY', '=');
               const energy = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_NOW', '='), 10);
               const power = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_POWER_NOW', '='), 10);
+              const voltage = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_VOLTAGE_NOW', '='), 10) / 1000;
+              const current = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CURRENT_NOW', '='), 10);
 
               result.percent = parseInt('0' + percent, 10);
               if (result.maxcapacity && result.currentcapacity) {
@@ -83,6 +85,12 @@ module.exports = function (callback) {
               }
               if (energy && power) {
                 result.timeremaining = Math.floor(energy / power * 60);
+              } else if (current && voltage && result.currentcapacity) {
+                const remaining = result.currentcapacity / voltage;
+                const current_rate = current / voltage;
+                if (remaining && current) {
+                  result.timeremaining = Math.floor(60 * remaining / current_rate);
+                }
               }
               result.type = util.getValue(lines, 'POWER_SUPPLY_TECHNOLOGY', '=');
               result.model = util.getValue(lines, 'POWER_SUPPLY_MODEL_NAME', '=');


### PR DESCRIPTION
## Pull Request

In my case /sys/class/power_supply/BAT0/uevent only reports current and voltage, not energy and power when discharging. This PR adds support for calculating the remaining minutes to discharge using these values combined with the current capacity.
For reference, this is similar to how Polybar handles this: https://github.com/jaagr/polybar/blob/master/src/modules/battery.cpp#L66-L83

#### Changes proposed:

* [x] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

