### PR TITLE
Fix `ip` binary not being found on some flavors of Linux

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -73,7 +73,8 @@ function getMacAddresses() {
   let result = {};
   if (_linux || _freebsd || _openbsd) {
     if (typeof isIpAvailable === 'undefined') {
-      if (fs.existsSync('/sbin/ip')) {
+      let res = execSync("command -v ip || echo").toString(); // Piping output to echo prints a newline instead of erroring when the command hasn't been found
+      if (res !== "\n") {
         isIpAvailable = true;
       } else {
         isIpAvailable = false;


### PR DESCRIPTION
## Pull Request

This is a fix for an issue reported downstream at https://github.com/GitSquared/edex-ui/issues/227

#### Changes proposed:

* [X] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

Following [this issue](https://github.com/sebhildebrandt/systeminformation/issues/114) that I reported back in March, support was added for using `ip` instead of `ifconfig` to detect network interfaces on Linux (9d13697, shipped in v3.37.5).

However, on some distros, `ip` isn't located at `/sbin`, and because of this the library tries to use `ifconfig` instead, which fails because most of these bleeding-edge systems don't have it available.

This PR replaces the `/sbin/ip` file-exists check by a `command -v` one that will succeed if `ip` is available in $PATH.