### PR TITLE
Increase reliability of util.getWmic()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -220,12 +220,7 @@ function findObjectByKey(array, key, value) {
 }
 
 function getWmic() {
-  if (os.type() === 'Windows_NT' && !wmic) {
-    if (fs.existsSync(process.env.WINDIR + '\\system32\\wbem\\wmic.exe')) {
-      wmic = process.env.WINDIR + '\\system32\\wbem\\wmic.exe';
-    } else wmic = 'wmic';
-  }
-  return wmic;
+  return execSync('WHERE WMIC').toString().trim();
 }
 
 function powerShell(cmd) {


### PR DESCRIPTION
This pull request will increase the reliability of the util.getWMIC() function using the built in windows command "WHERE WMIC" instead of checking for a specific filepath.