### PR TITLE
Fix wmic hang on windows xp

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -189,7 +189,7 @@ module.exports = function (callback) {
             }
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -507,8 +507,8 @@ function getCpu() {
                 });
               }
               resolve(result);
-            });
-          });
+            }).stdin.end();
+          }).stdin.end();
         } catch (e) {
           resolve(result);
         }
@@ -717,7 +717,7 @@ function cpuTemperature(callback) {
             }
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);
@@ -958,8 +958,8 @@ function cpuCache(callback) {
               }
               if (callback) { callback(result); }
               resolve(result);
-            });
-          });
+            }).stdin.end();
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -95,7 +95,7 @@ function fsSize(callback) {
               callback(data);
             }
             resolve(data);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(data); }
           resolve(data);
@@ -952,7 +952,7 @@ function diskLayout(callback) {
               }
               resolve(result);
             }
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -235,7 +235,7 @@ function mem(callback) {
 
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);
@@ -379,7 +379,7 @@ function memLayout(callback) {
             }
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -529,7 +529,7 @@ function versions(callback) {
                 }
               }
               functionProcessed();
-            });
+            }).stdin.end();
           } else {
             exec('postgres -V', function (error, stdout) {
               if (!error) {

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -297,7 +297,7 @@ function services(srv, callback) {
                 if (callback) { callback(result); }
                 resolve(result);
               }
-            });
+            }).stdin.end();
           } catch (e) {
             if (callback) { callback(result); }
             resolve(result);
@@ -749,7 +749,7 @@ function processes(callback) {
                 callback(result);
               }
               resolve(result);
-            });
+            }).stdin.end();
           } catch (e) {
             if (callback) { callback(result); }
             resolve(result);
@@ -859,7 +859,7 @@ function processLoad(proc, callback) {
                 }
                 resolve(result);
               }
-            });
+            }).stdin.end();
           } catch (e) {
             if (callback) { callback(result); }
             resolve(result);

--- a/lib/system.js
+++ b/lib/system.js
@@ -223,11 +223,11 @@ function system(callback) {
                 }
                 if (callback) { callback(result); }
                 resolve(result);
-              });
+              }).stdin.end();
             }
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);
@@ -320,7 +320,7 @@ function bios(callback) {
 
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);
@@ -422,7 +422,7 @@ function baseboard(callback) {
 
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);
@@ -543,7 +543,7 @@ function chassis(callback) {
 
             if (callback) { callback(result); }
             resolve(result);
-          });
+          }).stdin.end();
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);


### PR DESCRIPTION
wmic on Windows XP unfortunately doesn't exit unless exec().stdin.end() is called, which results in any request hanging forever.

Simply adding stdin.end() to any wmic exec() call solves this, and shouldn't affect other versions. (stdin isn't used in any of the calls, so calling end is fine)