### PR TITLE
windows graphics resolve result when encountered an error

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -497,6 +497,9 @@ function graphics(callback) {
                 }
                 resolve(result);
               });
+            } else {
+              if (callback) { callback(result); }
+              resolve(result);
             }
           });
         } catch (e) {


### PR DESCRIPTION
if encountered an error in the command, promise status will always be pending, I think resolve a result is better