### PR TITLE
add support for netbsd

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -23,6 +23,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -101,7 +102,7 @@ module.exports = function (callback) {
           resolve(result);
         }
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('sysctl hw.acpi.battery hw.acpi.acline', function (error, stdout) {
           let lines = stdout.toString().split('\n');
           const batteries = parseInt('0' + util.getValue(lines, 'hw.acpi.battery.units'), 10);

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -24,6 +24,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -355,7 +356,7 @@ function getCpu() {
           });
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         let modelline = '';
         let lines = [];
         if (os.cpus()[0] && os.cpus()[0].model) modelline = os.cpus()[0].model;
@@ -659,7 +660,7 @@ function cpuTemperature(callback) {
           }
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('sysctl dev.cpu | grep temp', function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
@@ -792,7 +793,7 @@ function cpuFlags(callback) {
           }
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('export LC_ALL=C; dmidecode -t 4 2>/dev/null; unset LC_ALL', function (error, stdout) {
           let flags = [];
           if (!error) {
@@ -870,7 +871,7 @@ function cpuCache(callback) {
           resolve(result);
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('export LC_ALL=C; dmidecode -t 7 2>/dev/null; unset LC_ALL', function (error, stdout) {
           let cache = [];
           if (!error) {

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -23,6 +23,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -39,11 +40,11 @@ function fsSize(callback) {
   return new Promise((resolve) => {
     process.nextTick(() => {
       let data = [];
-      if (_linux || _freebsd || _openbsd || _darwin) {
+      if (_linux || _freebsd || _netbsd || _openbsd || _darwin) {
         let cmd = '';
         if (_darwin) cmd = 'df -lkP | grep ^/';
         if (_linux) cmd = 'df -lkPT | grep ^/';
-        if (_freebsd || _openbsd) cmd = 'df -lkPT';
+        if (_freebsd || _netbsd || _openbsd) cmd = 'df -lkPT';
         exec(cmd, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
@@ -54,10 +55,10 @@ function fsSize(callback) {
                 if (line && (line[0].startsWith('/')) || (line[6] && line[6] === '/')) {
                   data.push({
                     'fs': line[0],
-                    'type': ((_linux || _freebsd || _openbsd) ? line[1] : 'HFS'),
-                    'size': parseInt(((_linux || _freebsd || _openbsd) ? line[2] : line[1])) * 1024,
-                    'used': parseInt(((_linux || _freebsd || _openbsd) ? line[3] : line[2])) * 1024,
-                    'use': parseFloat((100.0 * ((_linux || _freebsd || _openbsd) ? line[3] : line[2]) / ((_linux || _freebsd || _openbsd) ? line[2] : line[1])).toFixed(2)),
+                    'type': ((_linux || _freebsd || _netbsd || _openbsd) ? line[1] : 'HFS'),
+                    'size': parseInt(((_linux || _freebsd || _netbsd || _openbsd) ? line[2] : line[1])) * 1024,
+                    'used': parseInt(((_linux || _freebsd || _netbsd || _openbsd) ? line[3] : line[2])) * 1024,
+                    'use': parseFloat((100.0 * ((_linux || _freebsd || _netbsd || _openbsd) ? line[3] : line[2]) / ((_linux || _freebsd || _netbsd || _openbsd) ? line[2] : line[1])).toFixed(2)),
                     'mount': line[line.length - 1]
                   });
                 }
@@ -119,7 +120,7 @@ function fsOpenFiles(callback) {
         allocated: -1,
         available: -1
       };
-      if (_freebsd || _openbsd || _darwin) {
+      if (_freebsd || _netbsd || _openbsd || _darwin) {
         let cmd = 'sysctl -a | grep \'kern.*files\'';
         exec(cmd, function (error, stdout) {
           if (!error) {
@@ -587,7 +588,7 @@ function disksIO(callback) {
       let wIO = 0;
 
       if ((_disk_io && !_disk_io.ms) || (_disk_io && _disk_io.ms && Date.now() - _disk_io.ms >= 500)) {
-        if (_linux || _freebsd || _openbsd) {
+        if (_linux || _freebsd || _netbsd || _openbsd) {
           // prints Block layer statistics for all mounted volumes
           // var cmd = "for mount in `lsblk | grep / | sed -r 's/│ └─//' | cut -d ' ' -f 1`; do cat /sys/block/$mount/stat | sed -r 's/ +/;/g' | sed -r 's/^;//'; done";
           // var cmd = "for mount in `lsblk | grep / | sed 's/[│└─├]//g' | awk '{$1=$1};1' | cut -d ' ' -f 1 | sort -u`; do cat /sys/block/$mount/stat | sed -r 's/ +/;/g' | sed -r 's/^;//'; done";
@@ -802,7 +803,7 @@ function diskLayout(callback) {
           }
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         if (callback) { callback(result); }
         resolve(result);
       }

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -23,6 +23,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -461,7 +462,7 @@ function graphics(callback) {
           });
         }
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         if (callback) { callback(result); }
         resolve(result);
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,7 @@ function getDynamicData(srv, iface, callback) {
         });
       }
 
-      if (!_openbsd && && !_netbsd && !_freebsd && !_sunos) {
+      if (!_openbsd && !_netbsd && !_freebsd && !_sunos) {
         network.networkStats(iface).then(res => {
           data.networkStats = res;
           functionProcessed();

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,7 @@ const docker = require('./docker');
 let _platform = process.platform;
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -139,7 +140,7 @@ function getDynamicData(srv, iface, callback) {
       let functionProcessed = (function () {
         let totalFunctions = 14;
         if (_windows) totalFunctions = 10;
-        if (_freebsd || _openbsd) totalFunctions = 11;
+        if (_freebsd || _netbsd || _openbsd) totalFunctions = 11;
         if (_sunos) totalFunctions = 6;
 
         return function () {
@@ -203,7 +204,7 @@ function getDynamicData(srv, iface, callback) {
         });
       }
 
-      if (!_openbsd && !_freebsd && !_sunos) {
+      if (!_openbsd && && !_netbsd && !_freebsd && !_sunos) {
         network.networkStats(iface).then(res => {
           data.networkStats = res;
           functionProcessed();
@@ -243,14 +244,14 @@ function getDynamicData(srv, iface, callback) {
         });
       }
 
-      if (!_windows && !_openbsd && !_freebsd && !_sunos) {
+      if (!_windows && !_openbsd && !_netbsd && !_freebsd && !_sunos) {
         filesystem.fsStats().then(res => {
           data.fsStats = res;
           functionProcessed();
         });
       }
 
-      if (!_windows && !_openbsd && !_freebsd && !_sunos) {
+      if (!_windows && !_openbsd && !_netbsd && !_freebsd && !_sunos) {
         filesystem.disksIO().then(res => {
           data.disksIO = res;
           functionProcessed();

--- a/lib/internet.js
+++ b/lib/internet.js
@@ -22,6 +22,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -42,7 +43,7 @@ function inetChecksite(url, callback) {
       if (url) {
         url = url.toLowerCase();
         let t = Date.now();
-        if (_linux || _freebsd || _openbsd || _darwin || _sunos) {
+        if (_linux || _freebsd || _netbsd || _openbsd || _darwin || _sunos) {
           let args = ' -I --connect-timeout 5 -m 5 ' + url + ' 2>/dev/null | head -n 1 | cut -d " " -f2';
           let cmd = 'curl';
           exec(cmd + args, function (error, stdout) {
@@ -111,11 +112,11 @@ function inetLatency(host, callback) {
   return new Promise((resolve) => {
     process.nextTick(() => {
       let cmd;
-      if (_linux || _freebsd || _openbsd || _darwin) {
+      if (_linux || _freebsd || _netbsd || _openbsd || _darwin) {
         if (_linux) {
           cmd = 'ping -c 2 -w 3 ' + host + ' | grep rtt';
         }
-        if (_freebsd || _openbsd) {
+        if (_freebsd || _netbsd || _openbsd) {
           cmd = 'ping -c 2 -t 3 ' + host + ' | grep round-trip';
         }
         if (_darwin) {

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -23,6 +23,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -158,7 +159,7 @@ function mem(callback) {
           resolve(result);
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('/sbin/sysctl -a | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
@@ -260,7 +261,7 @@ function memLayout(callback) {
 
       let result = [];
 
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         exec('export LC_ALL=C; dmidecode -t memory 2>/dev/null | grep -iE "Size:|Type|Speed|Manufacturer|Form Factor|Locator|Memory Device|Serial Number|Voltage|Part Number"; unset LC_ALL', function (error, stdout) {
           if (!error) {
             let devices = stdout.toString().split('Memory Device');

--- a/lib/network.js
+++ b/lib/network.js
@@ -25,6 +25,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -58,11 +59,11 @@ function getDefaultNetworkInterface() {
     }
   }
   ifacename = ifacename || ifacenameFirst || '';
-  if (_linux || _darwin || _freebsd || _openbsd || _sunos) {
+  if (_linux || _darwin || _freebsd || _netbsd || _openbsd || _sunos) {
     let cmd = '';
     if (_linux) cmd = 'ip route 2> /dev/null | grep default | awk \'{print $5}\'';
     if (_darwin) cmd = 'route get 0.0.0.0 2>/dev/null | grep interface: | awk \'{print $2}\'';
-    if (_freebsd || _openbsd || _sunos) cmd = 'route get 0.0.0.0 | grep interface:';
+    if (_freebsd || _netbsd || _openbsd || _sunos) cmd = 'route get 0.0.0.0 | grep interface:';
     let result = execSync(cmd);
     ifacename = result.toString().split('\n')[0];
     if (ifacename.indexOf(':') > -1) {
@@ -80,7 +81,7 @@ function getMacAddresses() {
   let iface = '';
   let mac = '';
   let result = {};
-  if (_linux || _freebsd || _openbsd) {
+  if (_linux || _freebsd || _netbsd || _openbsd) {
     if (typeof pathToIp === 'undefined') {
       try {
         const lines = execSync('which ip').toString().split('\n');
@@ -384,7 +385,7 @@ function networkInterfaces(callback) {
                 type = 'wireless';
               }
             }
-            if (_darwin || _freebsd || _openbsd) {
+            if (_darwin || _freebsd || _netbsd || _openbsd) {
               nics.forEach(nic => {
                 if (nic.iface === dev) {
                   mtu = nic.mtu;
@@ -595,7 +596,7 @@ function networkStatsSingle(iface) {
             resolve(result);
           }
         }
-        if (_freebsd || _openbsd) {
+        if (_freebsd || _netbsd || _openbsd) {
           cmd = 'netstat -ibndI ' + iface;
           exec(cmd, function (error, stdout) {
             if (!error) {
@@ -707,9 +708,9 @@ function networkConnections(callback) {
   return new Promise((resolve) => {
     process.nextTick(() => {
       let result = [];
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         let cmd = 'netstat -tuna | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN\\|VERBUNDEN"';
-        if (_freebsd || _openbsd) cmd = 'netstat -na | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN\\|VERBUNDEN"';
+        if (_freebsd || _netbsd || _openbsd) cmd = 'netstat -na | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN\\|VERBUNDEN"';
         exec(cmd, { maxBuffer: 1024 * 2000 }, function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');

--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -24,6 +24,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -96,6 +97,9 @@ function getLogoFile(distro) {
   }
   else if (distro.indexOf('openbsd') !== -1) {
     result = 'openbsd';
+  }
+  else if (distro.indexOf('netbsd') !== -1) {
+    result = 'netbsd';
   }
   else if (distro.indexOf('freebsd') !== -1) {
     result = 'freebsd';
@@ -220,7 +224,7 @@ function osInfo(callback) {
           //}
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
 
         exec('sysctl kern.ostype kern.osrelease kern.osrevision kern.hostuuid', function (error, stdout) {
           if (!error) {
@@ -680,7 +684,7 @@ function uuid(callback) {
           resolve(result);
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('kenv -q smbios.system.uuid', function (error, stdout) {
           if (!error) {
             result.os = stdout.toString().split('\n')[0].trim().toLowerCase();

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -25,6 +25,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -101,8 +102,8 @@ function services(srv, callback) {
         let dataSrv = [];
         let allSrv = [];
 
-        if (_linux || _freebsd || _openbsd || _darwin) {
-          if ((_linux || _freebsd || _openbsd) && srv === '*') {
+        if (_linux || _freebsd || _netbsd || _openbsd || _darwin) {
+          if ((_linux || _freebsd || _netbsd || _openbsd) && srv === '*') {
             srv = '';
             let tmpsrv = execSync('service --status-all 2> /dev/null').toString().split('\n');
             for (const s of tmpsrv) {
@@ -560,9 +561,9 @@ function processes(callback) {
       let cmd = '';
 
       if ((_processes_cpu.ms && Date.now() - _processes_cpu.ms >= 500) || _processes_cpu.ms === 0) {
-        if (_linux || _freebsd || _openbsd || _darwin || _sunos) {
+        if (_linux || _freebsd || _netbsd || _openbsd || _darwin || _sunos) {
           if (_linux) cmd = 'export LC_ALL=C; ps -axo pid:11,ppid:11,pcpu:6,pmem:6,pri:5,vsz:11,rss:11,ni:5,lstart:30,state:5,tty:15,user:20,command; unset LC_ALL';
-          if (_freebsd || _openbsd) cmd = 'export LC_ALL=C; ps -axo pid,ppid,pcpu,pmem,pri,vsz,rss,ni,lstart,state,tty,user,command; unset LC_ALL';
+          if (_freebsd || _netbsd || _openbsd) cmd = 'export LC_ALL=C; ps -axo pid,ppid,pcpu,pmem,pri,vsz,rss,ni,lstart,state,tty,user,command; unset LC_ALL';
           if (_darwin) cmd = 'export LC_ALL=C; ps -acxo pid,ppid,pcpu,pmem,pri,vsz,rss,nice,lstart,state,tty,user,command -r; unset LC_ALL';
           if (_sunos) cmd = 'ps -Ao pid,ppid,pcpu,pmem,pri,vsz,rss,nice,stime,s,tty,user,comm';
           exec(cmd, { maxBuffer: 1024 * 2000 }, function (error, stdout) {

--- a/lib/system.js
+++ b/lib/system.js
@@ -24,6 +24,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -41,7 +42,7 @@ function system(callback) {
         sku: '-',
       };
 
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         exec('export LC_ALL=C; dmidecode -t system 2>/dev/null; unset LC_ALL', function (error, stdout) {
           // if (!error) {
           let lines = stdout.toString().split('\n');
@@ -251,7 +252,7 @@ function bios(callback) {
         revision: '',
       };
       let cmd = '';
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         if (process.arch === 'arm') {
           cmd = 'cat /proc/cpuinfo | grep Serial';
 
@@ -345,7 +346,7 @@ function baseboard(callback) {
         assetTag: '-',
       };
       let cmd = '';
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         if (process.arch === 'arm') {
           cmd = 'cat /proc/cpuinfo | grep Serial';
           // 'BCM2709', 'BCM2835', 'BCM2708' -->
@@ -485,7 +486,7 @@ function chassis(callback) {
         assetTag: '-',
         sku: '',
       };
-      if (_linux || _freebsd || _openbsd) {
+      if (_linux || _freebsd || _netbsd || _openbsd) {
         const cmd = `echo -n "chassis_asset_tag: "; cat /sys/devices/virtual/dmi/id/chassis_asset_tag 2>/dev/null; echo;
             echo -n "chassis_serial: "; cat /sys/devices/virtual/dmi/id/chassis_serial 2>/dev/null; echo;
             echo -n "chassis_type: "; cat /sys/devices/virtual/dmi/id/chassis_type 2>/dev/null; echo;

--- a/lib/users.js
+++ b/lib/users.js
@@ -22,6 +22,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 const _sunos = (_platform === 'sunos');
 
@@ -211,7 +212,7 @@ function users(callback) {
           }
         });
       }
-      if (_freebsd || _openbsd) {
+      if (_freebsd || _netbsd || _openbsd) {
         exec('who; echo "---"; w -ih', function (error, stdout) {
           if (!error) {
             // lines / split

--- a/lib/util.js
+++ b/lib/util.js
@@ -24,6 +24,7 @@ const _linux = (_platform === 'linux');
 const _darwin = (_platform === 'darwin');
 const _windows = (_platform === 'win32');
 const _freebsd = (_platform === 'freebsd');
+const _netbsd = (_platform === 'netbsd');
 const _openbsd = (_platform === 'openbsd');
 // const _sunos = (_platform === 'sunos');
 
@@ -314,7 +315,7 @@ function getCodepage() {
     }
     return codepage;
   }
-  if (_linux || _darwin || _freebsd || _openbsd) {
+  if (_linux || _darwin || _freebsd || _netbsd || _openbsd) {
     if (!codepage) {
       try {
         const stdout = execSync('echo $LANG');

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "osx",
     "windows",
     "freebsd",
+    "netbsd",
     "cpu",
     "cpuload",
     "physical cores",
@@ -71,6 +72,7 @@
     "linux",
     "win32",
     "freebsd",
+    "netbsd",
     "openbsd",
     "sunos"
   ],


### PR DESCRIPTION
this patch adds limited support for netbsd (matching openbsd and freebsd). 

netbsd is similar enough to openbsd for this use case that it can just use the same code paths as openbsd.

this patch is not thoroughly tested yet.