### PR TITLE
CpuTemperatureData types fix

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -89,9 +89,9 @@ export namespace Systeminformation {
   }
 
   interface CpuTemperatureData {
-    main: string;
-    cores: string;
-    max: string;
+    main: number;
+    cores: number[];
+    max: number;
   }
 
   interface MemData {


### PR DESCRIPTION
CpuTemperatureData interface lists max, main, and cores as strings, when max and main are actually numbers, and cores is an array of numbers. this is causing TS to through errors when using these properties, so updated them to reflect the appropriate types.