### PR TITLE
Added ExecutablePath to windows process query

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -684,6 +684,7 @@ function processes(callback) {
                     let utime = parseInt(util.getValue(lines, 'UserModeTime', '=', true), 10);
                     let stime = parseInt(util.getValue(lines, 'KernelModeTime', '=', true), 10);
                     let mem = parseInt(util.getValue(lines, 'WorkingSetSize', '=', true), 10);
+                    let exepath = util.getValue(lines, 'ExecutablePath', '=', true);
                     allcpuu = allcpuu + utime;
                     allcpus = allcpus + stime;
                     result.all++;
@@ -715,7 +716,8 @@ function processes(callback) {
                       state: (!statusValue ? _winStatusValues[0] : _winStatusValues[statusValue]),
                       tty: '',
                       user: '',
-                      command: commandLine || name
+                      command: commandLine || name,
+                      executablepath: exepath
                     });
                   }
                 }


### PR DESCRIPTION
Been working on a project that required polling wmi for running processes and their executable path. This library was great but was missing executable path. Not sure if that is intentional, but I noticed I could add it myself fairly easily and figured it might be worth a pull request. More than happy to just use my modified fork of the library if you do not wish to merge.