### PR TITLE
added windows display positions to graphics()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ For major (breaking) changes - version 3 and 2 see end of page.
 
 | Version        | Date           | Comment  |
 | -------------- | -------------- | -------- |
+| 4.12.3         | 2019-06-27     | `graphics()` added windows display positions |
 | 4.12.2         | 2019-06-24     | `system()` added Raspberry PI 4 detection |
 | 4.12.1         | 2019-06-24     | `networkInterface()` virtual interfaces macos, `networkInterfaceDefault()` |
 | 4.12.0         | 2019-06-21     | `networkInterface()` added property virtual |

--- a/docs/graphics.html
+++ b/docs/graphics.html
@@ -275,6 +275,26 @@
                     <td></td>
                     <td>current refresh rate</td>
                   </tr>
+                  <tr>
+                    <td></td>
+                    <td>...[0].positionX</td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>X</td>
+                    <td></td>
+                    <td>x position of the monitor</td>
+                  </tr>
+                  <tr>
+                    <td></td>
+                    <td>...[0].positionY</td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td>X</td>
+                    <td></td>
+                    <td>y position of the monitor</td>
+                  </tr>
                 </tbody>
               </table>
             </div>

--- a/docs/history.html
+++ b/docs/history.html
@@ -84,6 +84,11 @@
                 </thead>
                 <tbody>
                   <tr>
+                    <th scope="row">4.12.3</th>
+                    <td>2019-06-27</td>
+                    <td><span class="code">graphics()</span> added windows display positions</td>
+                  </tr>
+                  <tr>
                     <th scope="row">4.12.2</th>
                     <td>2019-06-24</td>
                     <td><span class="code">system()</span> added Raspberry PI 4 detection</td>

--- a/docs/index.html
+++ b/docs/index.html
@@ -168,7 +168,7 @@
       <img class="logo" src="assets/logo.png">
       <div class="title">systeminformation</div>
       <div class="subtitle"><span id="typed"></span></div>
-      <div class="version">Current Version: <span id="version">4.12.2</span></div>
+      <div class="version">Current Version: <span id="version">4.12.3</span></div>
       <button class="btn btn-light" onclick="location.href='https://github.com/sebhildebrandt/systeminformation'">View on Github <i class=" fab fa-github"></i></button>
     </div>
     <div class="down">

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -703,6 +703,8 @@ function graphics(callback) {
           pixeldepth: bitsPerPixel,
           currentResX: util.toInt(util.getValue(bounds, 'Width', '=')),
           currentResY: util.toInt(util.getValue(bounds, 'Height', '=')),
+          positionX: util.toInt(util.getValue(bounds, 'X', '=')),
+          positionY: util.toInt(util.getValue(bounds, 'Y', '=')),
         });
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "systeminformation",
-  "version": "4.12.2",
+  "version": "4.12.3",
   "description": "Simple system and OS information library",
   "license": "MIT",
   "author": "Sebastian Hildebrandt <hildebrandt@plus-innovations.com> (https://plus-innovations.com)",


### PR DESCRIPTION
Found a value was missing that I needed so I added a few lines :).
There is a way to get this information on darwin platforms via 'defaults read /Library/Preferences/com.apple.windowserver.plist' (https://stackoverflow.com/questions/20099333/terminal-command-to-show-connected-displays-monitors-resolutions)
and I'm sure there are ways to get it via linux, but I currently do not have access to develop/test them.