### PR TITLE
Fix incorrect battery acconnected on Windows.

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -185,7 +185,7 @@ module.exports = function (callback) {
                 result.percent = parseInt(util.getValue(lines, 'EstimatedChargeRemaining', '=') || 0);
                 result.currentcapacity = parseInt(result.maxcapacity * result.percent / 100);
                 result.ischarging = (statusValue >= 6 && statusValue <= 9) || statusValue === 11 || (!(statusValue === 3) && !(statusValue === 1) && result.percent < 100);
-                result.acconnected = result.ischarging;
+                result.acconnected = result.ischarging || statusValue === 2;
               }
             }
             if (callback) { callback(result); }


### PR DESCRIPTION
acconnected incorrectly reports false on Windows when plugged in if the battery is on 100%. Fix acconnected to report true if the statusValue is 2, because this means that the device is definitely plugged in even if it is not charging.