### PR TITLE
Address #290 incorrect calculation of active memory usage

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -143,11 +143,11 @@ function mem(callback) {
             result.available = parseInt(util.getValue(lines, 'memavailable'), 10);
             result.available = result.available ? result.available * 1024 : os.freemem();
 
-            // result.active = result.total - result.free - result.buffcache;
+            result.active = result.total - result.free - result.buffcache;
 
-            result.active = parseInt(util.getValue(lines, 'active'), 10);
-            result.active = result.active ? result.active * 1024 : 0;
-            result.buffcache = result.total - result.free - result.active;
+            //result.active = parseInt(util.getValue(lines, 'active'), 10);
+            //result.active = result.active ? result.active * 1024 : 0;
+            //result.buffcache = result.total - result.free - result.active;
 
             result.swaptotal = parseInt(util.getValue(lines, 'swaptotal'), 10);
             result.swaptotal = result.swaptotal ? result.swaptotal * 1024 : 0;

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -117,6 +117,9 @@ function mem(callback) {
 
         active: os.totalmem() - os.freemem(),     // temporarily (fallback)
         available: os.freemem(),                  // temporarily (fallback)
+        buffers: 0,
+        cached: 0,
+        slab: 0,
         buffcache: 0,
 
         swaptotal: 0,
@@ -134,20 +137,23 @@ function mem(callback) {
             result.free = result.free ? result.free * 1024 : os.freemem();
             result.used = result.total - result.free;
 
-            let buffers = parseInt(util.getValue(lines, 'buffers'), 10);
-            buffers = buffers ? buffers * 1024 : 0;
-            let cached = parseInt(util.getValue(lines, 'cached'), 10);
-            cached = cached ? cached * 1024 : 0;
-            result.buffcache = buffers + cached;
+            result.buffers = parseInt(util.getValue(lines, 'buffers'), 10);
+            result.buffers = result.buffers ? result.buffers * 1024 : 0;
+            result.cached = parseInt(util.getValue(lines, 'cached'), 10);
+            result.cached = result.cached ? result.cached * 1024 : 0;
+            result.slab = parseInt(util.getValue(lines, 'slab'), 10);
+            result.slab = result.slab ? result.slab * 1024 : 0;
+            result.buffcache = result.buffers + result.cached + result.slab;
 
             result.available = parseInt(util.getValue(lines, 'memavailable'), 10);
-            result.available = result.available ? result.available * 1024 : os.freemem();
 
-            result.active = result.total - result.free - result.buffcache;
-
-            //result.active = parseInt(util.getValue(lines, 'active'), 10);
-            //result.active = result.active ? result.active * 1024 : 0;
-            //result.buffcache = result.total - result.free - result.active;
+            if (result.available) {
+              result.available = result.available * 1024;
+              result.active = result.total - result.available;
+            } else {
+              result.available = os.freemem();
+              result.active = result.total - result.free - result.buffcache;              
+            }
 
             result.swaptotal = parseInt(util.getValue(lines, 'swaptotal'), 10);
             result.swaptotal = result.swaptotal ? result.swaptotal * 1024 : 0;


### PR DESCRIPTION
Reverts to the more correct calculation for active memory that is commented out in this file, and removes the incorrect override of buffcache.