### PR TITLE
Include sbin for ifconfig command

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -294,7 +294,7 @@ function parseLinesDarwinNics(sections) {
 }
 
 function getDarwinNics() {
-  const cmd = 'ifconfig -v';
+  const cmd = '/sbin/ifconfig -v';
   try {
     const lines = execSync(cmd, util.execOptsWin).toString().split('\n');
     const nsections = splitSectionsNics(lines);


### PR DESCRIPTION
This fixes the issue of a 'command not found' error on OS X while executing the systeminformation package in electron.