### PR TITLE
systeminformation should not return 0.00 as speed for unknown AMD

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -256,7 +256,7 @@ function cpuBrandManufacturer(res) {
 }
 
 function getAMDSpeed(brand) {
-  let result = '';
+  let result = '0.00';
   for (let key in AMDBaseFrequencies) {
     if (AMDBaseFrequencies.hasOwnProperty(key)) {
       let parts = key.split('|');
@@ -496,7 +496,7 @@ function getCpu() {
               if (!result.speed && result.brand.indexOf('AMD') > -1) {
                 result.speed = getAMDSpeed(result.brand);
               }
-              if (!result.speed) {
+              if (result.speed === '0.00') {
                 result.speed = result.speedmax;
               }
 

--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -256,7 +256,7 @@ function cpuBrandManufacturer(res) {
 }
 
 function getAMDSpeed(brand) {
-  let result = '0.00';
+  let result = '';
   for (let key in AMDBaseFrequencies) {
     if (AMDBaseFrequencies.hasOwnProperty(key)) {
       let parts = key.split('|');


### PR DESCRIPTION
As getAMDSpeed function returns '0.00' for unknown AMD (like Quad-Core AMD Opteron(tm) Processor 8384), **!result.speed** test was incorrect. 