### PR TITLE
Prevent "cat: /etc/network/interfaces: No such file or directory" log message'

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -498,7 +498,7 @@ function getLinuxDHCPNics() {
     util.noop();
   }
   try {
-    cmd = 'cat /etc/network/interfaces | grep iface';
+    cmd = 'cat /etc/network/interfaces 2> /dev/null | grep iface';
     const lines = execSync(cmd, { maxBuffer: 1024 * 20000 }).toString().split('\n');
     lines.forEach(line => {
       const parts = line.replace(/\s+/g, ' ').trim().split(' ');


### PR DESCRIPTION
Hello,

I was getting this message in the logs on Alpine Linux when calling `networkInterfaces()`:

```
> const si = require('systeminformation')
> si.networkInterfaces();
cat: /etc/network/interfaces: No such file or directory
```

This small change pipes stderr to /dev/null to prevent this message appearing in the logs.

Thanks for this package, it's very useful 😄.