### PR TITLE
Catch errors in getDefaultNetworkInterface()

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -170,11 +170,15 @@ function getMacAddresses() {
 
 function networkInterfaceDefault(callback) {
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     process.nextTick(() => {
-      let result = getDefaultNetworkInterface();
-      if (callback) { callback(result); }
-      resolve(result);
+      try {
+        let result = getDefaultNetworkInterface();
+        if (callback) { callback(result); }
+        resolve(result);
+      } catch (e) {
+        reject(e);
+      }
     });
   });
 }


### PR DESCRIPTION
Hi @sebhildebrandt,

Currently if an error is thrown when executing the `networkInterfaceDefault()` method it is impossible to catch the error as these are not passed up the promise chain, which results in the Node.js application crashing even when using try .. catch.

This change wraps the sync `getDefaultNetworkInterface` method in a try .. catch and rejects the promise if an error occurs.

I've noticed a few other places this problem is likely to occur as well, namely wherever `new Promise((resolve)` and `process.nextTick()` are used without a try -> catch -> reject handler.