### PR TITLE
Prevent log messages about port level mtu when running mellanox cards

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -173,7 +173,7 @@ function mem(callback) {
         });
       }
       if (_freebsd || _openbsd || _netbsd) {
-        exec('/sbin/sysctl -a | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', function (error, stdout) {
+        exec('/sbin/sysctl -a 2>/dev/null | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             const pagesize = parseInt(util.getValue(lines, 'vm.stats.vm.v_page_size'), 10);
@@ -209,7 +209,7 @@ function mem(callback) {
             result.buffcache = result.used - result.active;
             result.available = result.free + result.buffcache;
           }
-          exec('sysctl -n vm.swapusage', function (error, stdout) {
+          exec('sysctl -n vm.swapusage 2>/dev/null', function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               if (lines.length > 0) {


### PR DESCRIPTION
Hi @sebhildebrandt,

This should prevent the log messages one of my users is experiencing here: https://github.com/oznu/homebridge-config-ui-x/issues/499 when running Mellanox cards on FreeBSD.

```
mlx4_core0: port level mtu is only used for IB ports
```

The log message occurs when calling `mem()`.

Thanks!