### PR TITLE
osinfo.versions() added dotnet

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -243,6 +243,7 @@ export namespace Systeminformation {
     java: string;
     gcc: string;
     virtualbox: string;
+    dotnet: string;
   }
 
   interface UserData {

--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -384,11 +384,12 @@ function versions(callback) {
         pip3: '',
         java: '',
         gcc: '',
-        virtualbox: ''
+        virtualbox: '',
+        dotnet: '',
       };
 
       let functionProcessed = (function () {
-        let totalFunctions = 25;
+        let totalFunctions = 26;
         return function () {
           if (--totalFunctions === 0) {
             if (callback) {
@@ -691,6 +692,13 @@ function versions(callback) {
             const vbox = stdout.toString().split('\n')[0] || '';
             const parts = vbox.split('r');
             result.virtualbox = parts[0];
+          }
+          functionProcessed();
+        });
+        exec('dotnet --version 2>&1', function (error, stdout) {
+          if (!error) {
+            const dotnet = stdout.toString().split('\n')[0] || '';            
+            result.dotnet = dotnet.trim();
           }
           functionProcessed();
         });


### PR DESCRIPTION
Since dotnet core is widely used, (and also I needed too 😄) I've added support for dotnet core version.