### PR TITLE
memory.js: avoid creating a "cat" process

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -16,6 +16,7 @@
 const os = require('os');
 const exec = require('child_process').exec;
 const execSync = require('child_process').execSync;
+const readFile = require('fs').readFile;
 const util = require('./util');
 
 let _platform = process.platform;
@@ -143,9 +144,9 @@ function mem(callback) {
       };
 
       if (_linux) {
-        exec('export LC_ALL=C; cat /proc/meminfo 2>/dev/null ; unset LC_ALL', function (error, stdout) {
+        readFile('/proc/meminfo', 'ascii', function (error, data) {
           if (!error) {
-            const lines = stdout.toString().split('\n');
+            const lines = data.toString().split('\n');
             result.total = parseInt(util.getValue(lines, 'memtotal'), 10);
             result.total = result.total ? result.total * 1024 : os.totalmem();
             result.free = parseInt(util.getValue(lines, 'memfree'), 10);


### PR DESCRIPTION
using a `cat` process to read a file just not makes any sense, changed to avoid the forking overhead.