### PR TITLE
processes() fix names with space and no params

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -478,16 +478,18 @@ function processes(callback) {
     // try to figure out where parameter starts
     let firstParamPos = fullcommand.indexOf(' -');
     let firstParamPathPos = fullcommand.indexOf(' /');
-    firstParamPos = (firstParamPos >= 0 ? firstParamPos : 10000);
-    firstParamPathPos = (firstParamPathPos >= 0 ? firstParamPathPos : 10000);
+    // If there's no index for the firstParamPos and firstParamPathPos (-1)
+    // the command should have no params therefore it shouldn't be parsed
+    firstParamPos = (firstParamPos >= 0 || firstParamPos === -1 ? firstParamPos : 10000);
+    firstParamPathPos = (firstParamPathPos >= 0 || firstParamPos === -1 ? firstParamPathPos : 10000);
     const firstPos = Math.min(firstParamPos, firstParamPathPos);
-    let tmpCommand = fullcommand.substr(0, firstPos);
-    const tmpParams = fullcommand.substr(firstPos);
+    let tmpCommand = firstPos === -1 ? fullcommand : fullcommand.substr(0, firstPos);
+    const tmpParams =  firstPos === -1 ? '' : fullcommand.substr(firstPos);
     const lastSlashPos = tmpCommand.lastIndexOf('/');
     if (lastSlashPos >= 0) {
       path = tmpCommand.substr(0, lastSlashPos);
       tmpCommand = tmpCommand.substr(lastSlashPos + 1);
-    }
+    } 
 
     if (firstPos === 10000) {
       const parts = tmpCommand.split(' ');


### PR DESCRIPTION
Has described in #369 I noticed names with spaces and no params were being handled as if they had params.

This pull request handles that by not looking for params when `firstParamPos` and `firstParamPathPos` have no `-` and `/` respectively.