### PR TITLE
cpuTemperature() always show -1 on raspberry pi

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -816,8 +816,38 @@ function cpuTemperature(callback) {
                   result.max = tdieTemp;
                 }
               }
-              if (callback) { callback(result); }
-              resolve(result);
+              if (result.main === -1.0 && result.max === -1.0) {
+                fs.stat('/sys/class/thermal/thermal_zone0/temp', function (err) {
+                  if (err === null) {
+                    fs.readFile('/sys/class/thermal/thermal_zone0/temp', function (error, stdout) {
+                      if (!error) {
+                        let lines = stdout.toString().split('\n');
+                        if (lines.length > 0) {
+                          result.main = parseFloat(lines[0]) / 1000.0;
+                          result.max = result.main;
+                        }
+                      }
+                      if (callback) { callback(result); }
+                      resolve(result);
+                    });
+                  } else {
+                    exec('/opt/vc/bin/vcgencmd measure_temp', function (error, stdout) {
+                      if (!error) {
+                        let lines = stdout.toString().split('\n');
+                        if (lines.length > 0 && lines[0].indexOf('=')) {
+                          result.main = parseFloat(lines[0].split('=')[1]);
+                          result.max = result.main;
+                        }
+                      }
+                      if (callback) { callback(result); }
+                      resolve(result);
+                    });
+                  }
+                });
+              } else {
+                if (callback) { callback(result); }
+                resolve(result);
+              }
             } else {
               fs.stat('/sys/class/thermal/thermal_zone0/temp', function (err) {
                 if (err === null) {


### PR DESCRIPTION
Call cpuTemperature() and it always returns -1 for main and max temperature on raspberry pi.
After checking cpu.js, I found that command "sensors" do NOT trigger error in my raspberry pi and make the result always -1.

<p align="center">
  <img src="https://user-images.githubusercontent.com/33888917/83890595-89edc380-a77e-11ea-8de8-a402f5912d71.png" width="40%" height="40%">
  <img src="https://user-images.githubusercontent.com/33888917/83890688-adb10980-a77e-11ea-82f7-7106f3e6e3a9.png" width="40%" height="40%">
</p>



Modified codes of cpu.js and fixed the bug. Please check it out. Thanks.

<p align="center">
  <img src="https://user-images.githubusercontent.com/33888917/83890736-befa1600-a77e-11ea-8eea-318dbb366b3d.png" width="40%" height="40%">
  <img src="https://user-images.githubusercontent.com/33888917/83890778-cc170500-a77e-11ea-8786-9fbc7785dd18.png" width="40%" height="40%">
</p>



