### PR TITLE
fix: getDefaultNetworkInterface cost 30s on macOS

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -106,7 +106,7 @@ function getDefaultNetworkInterface() {
     if (_darwin || _freebsd || _openbsd || _netbsd || _sunos) {
       let cmd = '';
       if (_linux) cmd = 'ip route 2> /dev/null | grep default | awk \'{print $5}\'';
-      if (_darwin) cmd = 'route get 0.0.0.0 2>/dev/null | grep interface: | awk \'{print $2}\'';
+      if (_darwin) cmd = 'route -n get default 2>/dev/null | grep interface: | awk \'{print $2}\'';
       if (_freebsd || _openbsd || _netbsd || _sunos) cmd = 'route get 0.0.0.0 | grep interface:';
       let result = execSync(cmd);
       ifacename = result.toString().split('\n')[0];


### PR DESCRIPTION
On my MacBook Pro 2018, I use `route get default` to get interface, it will cost 30s to return the result.

![image](https://user-images.githubusercontent.com/15098719/92730918-03610780-f3a7-11ea-91ff-1f4bd1b11093.png)

By the way, it would be better to change `getDefaultNetworkInterface` to a async API to avoid blocking JavaScript main thread.