### PR TITLE
:package: missing osx-temperature-sensor

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,5 +118,8 @@
       "text"
     ],
     "all": true
+  },
+  "dependencies": {
+    "osx-temperature-sensor": "^1.0.7"
   }
 }


### PR DESCRIPTION
## What

/lib/cpu.js has

```
        try {
          osxTemp = require('osx-temperature-sensor');
        } catch (er) {
          osxTemp = null;
        }
```

So, it might be better to declare `osx-temperature-sensor` as a dependency