### PR TITLE
Use clinfo on linux if found for gpu detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ I also created a nice little command line tool called [mmon][mmon-github-url] (m
 | | ...[0].model | X |  | X | X |  | graphics controller model |
 | | ...[0].vendor | X |  | X | X |  | e.g. ATI |
 | | ...[0].bus | X |  | X | X |  | on which bus (e.g. PCIe) |
+| | ...[0].busAddress | X | | | | | PCI bus address (e.g. 26:00.0) |
 | | ...[0].vram | X |  | X | X |  | VRAM size (in MB) |
 | | ...[0].vramDynamic | X |  | X | X |  | true if dynamicly allocated ram |
 | | displays[] | X |  | X | X |  | monitor/display array |

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -200,6 +200,7 @@ function graphics(callback) {
       vendor: '',
       model: '',
       bus: '',
+      busAddress: '',
       vram: -1,
       vramDynamic: false
     };
@@ -233,6 +234,7 @@ function graphics(callback) {
                 vendor: '',
                 model: '',
                 bus: '',
+                busAddress: '',
                 vram: -1,
                 vramDynamic: false
               };
@@ -240,6 +242,7 @@ function graphics(callback) {
             isGraphicsController = true;
             let endpos = lines[i].search(/\[[0-9a-f]{4}:[0-9a-f]{4}]|$/);
             let parts = lines[i].substr(vgapos, endpos - vgapos).split(':');
+            currentController.busAddress = lines[i].substr(0, vgapos).trim();
             if (parts.length > 1) {
               parts[1] = parts[1].trim();
               if (parts[1].toLowerCase().indexOf('corporation') >= 0) {
@@ -286,46 +289,70 @@ function graphics(callback) {
         }
       }
     }
-    if (currentController.vendor || currentController.model || currentController.bus || currentController.vram !== -1 || currentController.vramDynamic) { // already a controller found
+    if (currentController.vendor || currentController.model || currentController.bus || currentController.busAddress || currentController.vram !== -1 || currentController.vramDynamic) { // already a controller found
       controllers.push(currentController);
     }
     return (controllers);
   }
 
-  function parseClinfoLinesLinuxControllers(lines) {
-    let regex = /\[(\w+\/\d+)\]\s*(\w+)\s*(.+)/gm
-    let controllers = [];
-    var m
-    while ((m = regex.exec(lines))) {
-      if (m.index === regex.lastIndex) {
-        regex.lastIndex++
+  function parseLinesLinuxClinfo(controllers, lines) {
+    const fieldPattern = /\[([^\]]+)\]\s+(\w+)\s+(.*)/;
+    const devices = lines.reduce((devices, line) => {
+      const field = fieldPattern.exec(line.trim());
+      if (field) {
+        if (!devices[field[1]]) {
+          devices[field[1]] = {};
+        }
+        devices[field[1]][field[2]] = field[3];
       }
-      // Create a key - object pair for each unique GPU. Useful to differentiate between different GPUs.
-      if (!Object.keys(controllers).includes(m[1])) {
-        controllers[m[1]] = {
-          vendor: '',
-          model: '',
-          bus: '',
-          vram: -1,
-          vramDynamic: false
+      return devices
+    }, {});
+    for (let deviceId in devices) {
+      const device = devices[deviceId]
+      if (device['CL_DEVICE_TYPE'] === 'CL_DEVICE_TYPE_GPU') {
+        let busAddress;
+        if (device['CL_DEVICE_TOPOLOGY_AMD']) {
+          const bdf = device['CL_DEVICE_TOPOLOGY_AMD'].match(/[a-zA-Z0-9]+:\d+.\d+/);
+          if (bdf) {
+            busAddress = bdf[0];
+          }
+        } else if (device['CL_DEVICE_PCI_BUS_ID_NV'] && device['CL_DEVICE_PCI_SLOT_ID_NV']) {
+          const bus = parseInt(device['CL_DEVICE_PCI_BUS_ID_NV']);
+          const slot = parseInt(device['CL_DEVICE_PCI_SLOT_ID_NV']);
+          if (!isNaN(bus) && !isNaN(slot)) {
+            const b = bus & 0xff;
+            const d = (slot >> 3) & 0xff;
+            const f = slot & 0x07;
+            busAddress = `${b.toString().padStart(2, '0')}:${d.toString().padStart(2, '0')}.${f}`;
+          }
+        }
+        if (busAddress) {
+          let controller = controllers.find(controller => controller.busAddress === busAddress);
+          if (!controller) {
+            controller = {
+              vendor: '',
+              model: '',
+              bus: '',
+              busAddress,
+              vram: -1,
+              vramDynamic: false
+            };
+            controllers.push(controller);
+          }
+          controller.vendor = device['CL_DEVICE_VENDOR'];
+          if (device['CL_DEVICE_BOARD_NAME_AMD']) {
+            controller.model = device['CL_DEVICE_BOARD_NAME_AMD'];
+          } else {
+            controller.model = device['CL_DEVICE_NAME'];
+          }
+          const memory = parseInt(device['CL_DEVICE_GLOBAL_MEM_SIZE']);
+          if (!isNaN(memory)) {
+            controller.vram = Math.round(memory / 1024 / 1024);
+          }
         }
       }
-      switch (m[2]) {
-        case 'CL_DEVICE_NAME':
-          controllers[m[1]]['model'] = m[3]
-          break
-        case 'CL_DEVICE_BOARD_NAME_AMD':
-          controllers[m[1]]['model'] = m[3]
-          break
-        case 'CL_DEVICE_VENDOR':
-          controllers[m[1]]['vendor'] = m[3]
-          break
-        case 'CL_DEVICE_GLOBAL_MEM_SIZE':
-          controllers[m[1]]['vram'] = Math.round(parseInt(m[3]) / 1024 / 1024)
-          break
-      }
     }
-    return (Object.values(controllers))
+    return controllers
   }
 
   function parseLinesLinuxEdid(edid) {
@@ -556,47 +583,39 @@ function graphics(callback) {
             resolve(result);
           });
         } else {
-          // Displays
-          let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
+          let cmd = 'lspci -vvv  2>/dev/null';
           exec(cmd, function (error, stdout) {
-            let depth = 0;
             if (!error) {
               let lines = stdout.toString().split('\n');
-              depth = parseInt(lines[0]) || 0;
+              result.controllers = parseLinesLinuxControllers(lines);
             }
-            cmd = 'xrandr --verbose 2>/dev/null';
+            let cmd = "clinfo --raw";
             exec(cmd, function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().split('\n');
-                result.displays = parseLinesLinuxDisplays(lines, depth);
+                result.controllers = parseLinesLinuxClinfo(result.controllers, lines);
               }
-              // Controllers
-              let cmd = "clinfo --raw";
+              let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
               exec(cmd, function (error, stdout) {
+                let depth = 0;
                 if (!error) {
-                  result.controllers = parseClinfoLinesLinuxControllers(stdout);
+                  let lines = stdout.toString().split('\n');
+                  depth = parseInt(lines[0]) || 0;
+                }
+                let cmd = 'xrandr --verbose 2>/dev/null';
+                exec(cmd, function (error, stdout) {
+                  if (!error) {
+                    let lines = stdout.toString().split('\n');
+                    result.displays = parseLinesLinuxDisplays(lines, depth);
+                  }
                   if (callback) {
                     callback(result);
                   }
                   resolve(result);
-                }
-                else {
-                  let cmd = 'lspci -vvv  2>/dev/null';
-                  exec(cmd, function (error, stdout) {
-                    if (!error) {
-                      let lines = stdout.toString().split('\n');
-                      result.controllers = parseLinesLinuxControllers(lines);
-                    }
-                    if (callback) {
-                      callback(result);
-                    }
-                    resolve(result);
-                  });
-                }
+                });
               });
             });
           });
-
         }
       }
       if (_freebsd || _openbsd || _netbsd) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -292,6 +292,45 @@ function graphics(callback) {
     return (controllers);
   }
 
+  function parseClinfoLinesLinuxControllers(lines) {
+    let regex = /\[(\w+\/\d+)\]\s*(\w+)\s*(.+)/gm
+    let controllers = [];
+    var m
+    while ((m = regex.exec(lines))) {
+      if (m.index === regex.lastIndex) {
+        regex.lastIndex++
+      }
+      // Create a key - object pair for each unique GPU. Useful to differentiate between different GPUs.
+      if (!Object.keys(controllers).includes(m[1])) {
+        controllers[m[1]] = {
+          vendor: '',
+          model: '',
+          bus: '',
+          vram: -1,
+          vramDynamic: false
+        }
+      }
+      switch (m[2]) {
+        case 'CL_DEVICE_NAME':
+          controllers[m[1]]['model'] = m[3]
+          break
+        case 'CL_DEVICE_BOARD_NAME_AMD':
+          controllers[m[1]]['model'] = m[3]
+          break
+        case 'CL_DEVICE_VENDOR':
+          controllers[m[1]]['vendor'] = m[3]
+          break
+        //case 'CL_DRIVER_VERSION':
+        //  controllers[m[1]]['driverVersion'] = m[3]
+        //  break
+        case 'CL_DEVICE_GLOBAL_MEM_SIZE':
+          controllers[m[1]]['vram'] = Math.round(parseInt(m[3]) / 1024 / 1024)
+          break
+      }
+    }
+    return (Object.values(controllers))
+  }
+
   function parseLinesLinuxEdid(edid) {
     // parsen EDID
     // --> model
@@ -520,29 +559,37 @@ function graphics(callback) {
             resolve(result);
           });
         } else {
-          let cmd = 'lspci -vvv  2>/dev/null';
+          let cmd = "clinfo --raw";
           exec(cmd, function (error, stdout) {
+            let clinfoFullfilled = false;
             if (!error) {
-              let lines = stdout.toString().split('\n');
-              result.controllers = parseLinesLinuxControllers(lines);
+              result.controllers = parseClinfoLinesLinuxControllers(stdout)
+              clinfoFullfilled = true;
             }
-            let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
+            let cmd = 'lspci -vvv  2>/dev/null';
             exec(cmd, function (error, stdout) {
-              let depth = 0;
-              if (!error) {
+              if (!error && !clinfoFullfilled) {
                 let lines = stdout.toString().split('\n');
-                depth = parseInt(lines[0]) || 0;
+                result.controllers = parseLinesLinuxControllers(lines);
               }
-              let cmd = 'xrandr --verbose 2>/dev/null';
+              let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
               exec(cmd, function (error, stdout) {
+                let depth = 0;
                 if (!error) {
                   let lines = stdout.toString().split('\n');
-                  result.displays = parseLinesLinuxDisplays(lines, depth);
+                  depth = parseInt(lines[0]) || 0;
                 }
-                if (callback) {
-                  callback(result);
-                }
-                resolve(result);
+                let cmd = 'xrandr --verbose 2>/dev/null';
+                exec(cmd, function (error, stdout) {
+                  if (!error) {
+                    let lines = stdout.toString().split('\n');
+                    result.displays = parseLinesLinuxDisplays(lines, depth);
+                  }
+                  if (callback) {
+                    callback(result);
+                  }
+                  resolve(result);
+                });
               });
             });
           });

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -320,9 +320,6 @@ function graphics(callback) {
         case 'CL_DEVICE_VENDOR':
           controllers[m[1]]['vendor'] = m[3]
           break
-        //case 'CL_DRIVER_VERSION':
-        //  controllers[m[1]]['driverVersion'] = m[3]
-        //  break
         case 'CL_DEVICE_GLOBAL_MEM_SIZE':
           controllers[m[1]]['vram'] = Math.round(parseInt(m[3]) / 1024 / 1024)
           break
@@ -559,40 +556,47 @@ function graphics(callback) {
             resolve(result);
           });
         } else {
-          let cmd = "clinfo --raw";
+          // Displays
+          let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
           exec(cmd, function (error, stdout) {
-            let clinfoFullfilled = false;
+            let depth = 0;
             if (!error) {
-              result.controllers = parseClinfoLinesLinuxControllers(stdout)
-              clinfoFullfilled = true;
+              let lines = stdout.toString().split('\n');
+              depth = parseInt(lines[0]) || 0;
             }
-            let cmd = 'lspci -vvv  2>/dev/null';
+            cmd = 'xrandr --verbose 2>/dev/null';
             exec(cmd, function (error, stdout) {
-              if (!error && !clinfoFullfilled) {
+              if (!error) {
                 let lines = stdout.toString().split('\n');
-                result.controllers = parseLinesLinuxControllers(lines);
+                result.displays = parseLinesLinuxDisplays(lines, depth);
               }
-              let cmd = 'xdpyinfo 2>/dev/null | grep \'depth of root window\' | awk \'{ print $5 }\'';
+              // Controllers
+              let cmd = "clinfo --raw";
               exec(cmd, function (error, stdout) {
-                let depth = 0;
                 if (!error) {
-                  let lines = stdout.toString().split('\n');
-                  depth = parseInt(lines[0]) || 0;
-                }
-                let cmd = 'xrandr --verbose 2>/dev/null';
-                exec(cmd, function (error, stdout) {
-                  if (!error) {
-                    let lines = stdout.toString().split('\n');
-                    result.displays = parseLinesLinuxDisplays(lines, depth);
-                  }
+                  result.controllers = parseClinfoLinesLinuxControllers(stdout);
                   if (callback) {
                     callback(result);
                   }
                   resolve(result);
-                });
+                }
+                else {
+                  let cmd = 'lspci -vvv  2>/dev/null';
+                  exec(cmd, function (error, stdout) {
+                    if (!error) {
+                      let lines = stdout.toString().split('\n');
+                      result.controllers = parseLinesLinuxControllers(lines);
+                    }
+                    if (callback) {
+                      callback(result);
+                    }
+                    resolve(result);
+                  });
+                }
               });
             });
           });
+
         }
       }
       if (_freebsd || _openbsd || _netbsd) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -312,7 +312,7 @@ function graphics(callback) {
       if (device['CL_DEVICE_TYPE'] === 'CL_DEVICE_TYPE_GPU') {
         let busAddress;
         if (device['CL_DEVICE_TOPOLOGY_AMD']) {
-          const bdf = device['CL_DEVICE_TOPOLOGY_AMD'].match(/[a-zA-Z0-9]+:\d+.\d+/);
+          const bdf = device['CL_DEVICE_TOPOLOGY_AMD'].match(/[a-zA-Z0-9]+:\d+\.\d+/);
           if (bdf) {
             busAddress = bdf[0];
           }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -245,6 +245,7 @@ export namespace Systeminformation {
     vendor: string;
     model: string;
     bus: string;
+    busAddress: string;
     vram: number;
     vramDynamic: boolean;
   }


### PR DESCRIPTION
This is still wip/in testing.
GPU VRAM detection on Linux is very inaccurate: Multiple GPUs are being detected to only have 256 MB of VRAM. By implementing a mix of utilities that can detect GPU information, more accurate system information can be retrieved.
I am using the clinfo command, if found on the user's system, to detect GPUs on the system. Using this allows for a much more accurate VRAM detection, and further opens the option to parse even more graphics information from the system. (Like GPU driver version, core clock, etc.)
@sebhildebrandt Please have a look at this PR and let me know if anything needs to be changed to your preference to create improved GPU information detection on Linux.