### PR TITLE
Update typings to reflect documentation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -365,9 +365,9 @@ export namespace Systeminformation {
   }
 
   interface FsStatsData {
-    rx_bytes: number;
-    wx_bytes: number;
-    tx_bytes: number;
+    rx: number;
+    wx: number;
+    tx: number;
     rx_sec: number;
     wx_sec: number;
     tx_sec: number;


### PR DESCRIPTION
Typings are yielding a different shape than what is returned (and documented), making `tsc` complain in my Typescript project