### PR TITLE
Issue #396: Don't hang dockerContainers() if docker.sock missing

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -162,6 +162,8 @@ function dockerContainers(all, callback) {
               if (callback) { callback(result); }
               resolve(result);
             }
+          } else {
+            resolve(result);
           }
         } catch (err) {
           // GC in _docker_container_stats


### PR DESCRIPTION
If the docker socket isn't found at `/var/run/docker.sock`, calls to dockerContainers() will hang indefinitely. This commit adds an
additional `else` conditional to capture the failure branch and ensure the relevant promise is resolved.