### PR TITLE
Feature: Device Name & Powershell 2.0 Fixes

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -724,6 +724,11 @@ function graphics(callback) {
       if (ssections[i].trim() !== '') {
         ssections[i] = 'BitsPerPixel ' + ssections[i];
         msections[i] = 'Active ' + msections[i];
+        // tsections can be empty on earlier versions of powershell (<=2.0). Tag connection type as UNKNOWN
+        // if this information is missing
+        if(tsections.length === 0) {
+          tsections[i] = 'Unknown';
+        }
 
         let linesScreen = ssections[i].split(os.EOL);
         let linesMonitor = msections[i].split(os.EOL);

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -615,7 +615,7 @@ function graphics(callback) {
               }
             });
             result.displays = parseLinesWindowsDisplaysPowershell(ssections, msections, dsections, tsections, isections);
-            
+
             if (result.displays.length === 1) {
               if (_resolutionx) {
                 result.displays[0].resolutionx = _resolutionx;


### PR DESCRIPTION
Adds device name to the returned data for Windows. We needed the device name returned by [System.Windows.Forms](https://docs.microsoft.com/en-us/dotnet/api/system.windows.forms.screen.devicename?view=netcore-3.1) so we added it.

One issue is it could lead to confusion as the device name is of the format:
```
\\.\DISPLAY1
\\.\DISPLAY2
```

However, we needed it for some internal items so we decided to PR it in case others may need access to this. 