### PR TITLE
Bugfix: Windows 7 Graphics Fixes (Multi Monitor)

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -722,9 +722,9 @@ function graphics(callback) {
       if (ssections[i].trim() !== '') {
         ssections[i] = 'BitsPerPixel ' + ssections[i];
         msections[i] = 'Active ' + msections[i];
-        // tsections can be empty on earlier versions of powershell (<=2.0). Tag connection type as UNKNOWN
-        // if this information is missing
-        if (tsections.length === 0) {
+        // tsections can be empty OR undefined on earlier versions of powershell (<=2.0)
+        // Tag connection type as UNKNOWN by default if this information is missing
+        if (tsections.length === 0 || tsections[i] === undefined) {
           tsections[i] = 'Unknown';
         }
         let linesScreen = ssections[i].split(os.EOL);


### PR DESCRIPTION
Corrects an issue where tsections can either be empty or ```undefined``` in multi-monitor setups on windows 7 x32/x64 when powershell is ```<= 2.0```;

On some systems running multiple monitor setups in these environments, the resulting tsections results in a single output instead of containing the necessary keys for each monitor.

```js
// Multiple monitors containing proper indexes for ssections, etc but tsections is just undefined after index 0
tsections[0] = ''
tsections[1] = undefined;
```

My previous fix assumed the indexes to be properly initialized. This is not the case, so multi-monitors silently throw when running: ```tsections[i].split(os.EOL);``` since it is not a string value.

A better fix may be to force tsections to initialize as ```unknown``` for each expected index but I'm not certain where this is best kept since it very much feels like a "just make i work" scenario when doing that. 

That fix would look something like a pre-check before looping over ssections and may be cleaner: 

```js
// Precheck the value of tsections 
// powershell versions <= 2.0 do not properly support detecting connection parameters
// So fill it with default values "unknown" if it is empty and ensure it matches the amount of screens available on the target machine
if(tsections.length === 0) {
    tsections = Array(ssections.length).fill('unknown');
}

for (let i = 0; i < ssections.length; i++) {
// rest of code
```

Feedback appreciated on which approach you'd prefer if any.