### PR TITLE
fix rpi processor names

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -718,10 +718,10 @@ function decodePiCpuinfo(lines) {
   }
 
   const processorList = [
-    'BMC2835',
-    'BMC2836',
-    'BMC2837',
-    'BMC2711',
+    'BCM2835',
+    'BCM2836',
+    'BCM2837',
+    'BCM2711',
   ];
   const manufacturerList = [
     'Sony UK',


### PR DESCRIPTION
The processor strings in processorList all start with BMC, but they should start with BCM.