### PR TITLE
updated nvidia-smi detection logic to use the latest nvidia-smi available if the user has previous installations

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -378,11 +378,15 @@ function graphics(callback) {
     if (_windows) {
       try {
         const basePath = util.WINDIR + '\\System32\\DriverStore\\FileRepository';
-        const dirContent = fs.readdirSync(basePath);
-        const candidateDirs = dirContent.filter(dir => dir.startsWith('nv'));
-        const targetDir = candidateDirs.find(dir => {
-          const content = fs.readdirSync([basePath, dir].join('/'));
-          return content.includes('nvidia-smi.exe');
+        // find all directories that have an nvidia-smi.exe file
+        const candidateDirs = fs.readdirSync(basePath).filter(dir => {
+            return fs.readdirSync([basePath, dir].join('/')).includes('nvidia-smi.exe');
+        });
+        // use the directory with the most recently created nvidia-smi.exe file
+        const targetDir = candidateDirs.reduce((prevDir, currentDir) => {
+            const previousNvidiaSmi = fs.statSync([basePath, prevDir, 'nvidia-smi.exe'].join('/'));
+            const currentNvidiaSmi = fs.statSync([basePath, currentDir, 'nvidia-smi.exe'].join('/'));
+            return (previousNvidiaSmi.ctimeMs > currentNvidiaSmi.ctimeMs) ? prevDir : currentDir;
         });
 
         if (targetDir) {


### PR DESCRIPTION
If the user has previous installations of the Nvidia drivers, the current logic will use the first directory in the list of candidateDirs, but the directory may not be consistent with the user's currently installed Nvidia Drivers. This pull request will use the nvidia-smi with the most recent creation date, which will also be the installation date of the Nvidia drivers currently in use on the system.