### PR TITLE
Fix: graphics() Virtual graphics devices.

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -887,10 +887,10 @@ function graphics(callback) {
         if (sections[i].trim() !== '') {
 
           let lines = sections[i].trim().split('\r\n');
-          let pnpDeviceId = util.getValue(lines, 'PNPDeviceID', '=').match(/SUBSYS_[a-fA-F\d]{8}/)
+          let pnpDeviceId = util.getValue(lines, 'PNPDeviceID', '=').match(/SUBSYS_[a-fA-F\d]{8}/);
           if (!pnpDeviceId) {
             // Example: ROOT\SPACEDESK_GRAPHICS_ADAPTER\0000
-            continue
+            continue;
           }
           let subDeviceId = pnpDeviceId[0];
           if (subDeviceId) {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -887,7 +887,12 @@ function graphics(callback) {
         if (sections[i].trim() !== '') {
 
           let lines = sections[i].trim().split('\r\n');
-          let subDeviceId = util.getValue(lines, 'PNPDeviceID', '=').match(/SUBSYS_[a-fA-F\d]{8}/)[0];
+          let pnpDeviceId = util.getValue(lines, 'PNPDeviceID', '=').match(/SUBSYS_[a-fA-F\d]{8}/)
+          if (!pnpDeviceId) {
+            // Example: ROOT\SPACEDESK_GRAPHICS_ADAPTER\0000
+            continue
+          }
+          let subDeviceId = pnpDeviceId[0];
           if (subDeviceId) {
             subDeviceId = subDeviceId.split('_')[1];
           }


### PR DESCRIPTION
When the user has installed a virtual graphics device like [spacedesk](https://spacedesk.net/), the `graphics()` function will return empty results for both `.controllers` and `.displays` due to an error.

The error occurs specifically on line 890:
```
let subDeviceId = util.getValue(lines, 'PNPDeviceID', '=').match(/SUBSYS_[a-fA-F\d]{8}/)[0];
```

The spacedesk device has the value `PNPDeviceID=ROOT\SPACEDESK_GRAPHICS_ADAPTER\0000`  which causes `.match(/SUBSYS_[a-fA-F\d]{8}/)` to return `null`.

The proposed change only ensures that devices where `.match` returns `null` are ignored, however a more appropriate fix is required to show spacedesk and others on the list.