### PR TITLE
filesystem.js: Fix fsStats() linux block devices

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -509,13 +509,13 @@ function fsStats(callback) {
       if ((_fs_speed && !_fs_speed.ms) || (_fs_speed && _fs_speed.ms && Date.now() - _fs_speed.ms >= 500)) {
         if (_linux) {
           // exec("df -k | grep /dev/", function(error, stdout) {
-          exec('lsblk 2>/dev/null | grep /', function (error, stdout) {
+          exec('lsblk 2>/dev/null -r | grep /', function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
               let fs_filter = [];
               lines.forEach(function (line) {
                 if (line !== '') {
-                  line = line.replace(/[├─│└]+/g, '').trim().split(' ');
+                  line = line.trim().split(' ');
                   if (fs_filter.indexOf(line[0]) === -1) { fs_filter.push(line[0]); }
                 }
               });


### PR DESCRIPTION
The current implementation of fsStats is not working correctly.