### PR TITLE
Fix windows iface not displaying correctly for non-active interfaces

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -221,6 +221,7 @@ function parseLinesWindowsNics(sections, nconfigsections) {
         let netEnabled = util.getValue(lines, 'NetEnabled', '=');
         let adapterType = util.getValue(lines, 'AdapterTypeID', '=') === '9' ? 'wireless' : 'wired';
         let ifacename = util.getValue(lines, 'Name', '=').replace(/\]/g, ')').replace(/\[/g, '(');
+        let iface = util.getValue(lines, 'NetConnectionID', '=').replace(/\]/g, ')').replace(/\[/g, '(');
         if (ifacename.toLowerCase().indexOf('wi-fi') >= 0 || ifacename.toLowerCase().indexOf('wireless') >= 0) {
           adapterType = 'wireless';
         }
@@ -230,6 +231,7 @@ function parseLinesWindowsNics(sections, nconfigsections) {
             mac: util.getValue(lines, 'MACAddress', '=').toLowerCase(),
             dhcp: util.getValue(linesNicConfig, 'dhcpEnabled', '=').toLowerCase(),
             name: ifacename,
+            iface: iface,
             netEnabled: netEnabled === 'TRUE',
             speed: isNaN(speed) ? null : speed,
             operstate: util.getValue(lines, 'NetConnectionStatus', '=') === '2' ? 'up' : 'down',
@@ -243,7 +245,7 @@ function parseLinesWindowsNics(sections, nconfigsections) {
 }
 
 function getWindowsNics() {
-  const cmd = util.getWmic() + ' nic get MACAddress, name, NetEnabled, Speed, NetConnectionStatus, AdapterTypeId /value';
+  const cmd = util.getWmic() + ' nic get MACAddress, name, NetConnectionId, NetEnabled, Speed, NetConnectionStatus, AdapterTypeId /value';
   const cmdnicconfig = util.getWmic() + ' nicconfig get dhcpEnabled /value';
   try {
     const nsections = execSync(cmd, util.execOptsWin).split(/\n\s*\n/);
@@ -773,7 +775,9 @@ function networkInterfaces(callback, rescan = true) {
           if (_linux) {
             _dhcpNics = getLinuxDHCPNics();
           }
+
           for (let dev in ifaces) {
+            let iface = dev;
             let ip4 = '';
             let ip4subnet = '';
             let ip6 = '';
@@ -869,10 +873,10 @@ function networkInterfaces(callback, rescan = true) {
               }
               if (_windows) {
 
-
                 dnsSuffix = getWindowsIfaceDNSsuffix(dnsSuffixes.ifaces, dev);
                 nics.forEach(detail => {
                   if (detail.mac === mac) {
+                    iface = detail.iface || iface;
                     ifaceName = detail.name;
                     dhcp = detail.dhcp;
                     operstate = detail.operstate;
@@ -880,6 +884,7 @@ function networkInterfaces(callback, rescan = true) {
                     type = detail.type;
                   }
                 });
+
 
                 if (dev.toLowerCase().indexOf('wlan') >= 0 || ifaceName.toLowerCase().indexOf('wlan') >= 0 || ifaceName.toLowerCase().indexOf('802.11n') >= 0 || ifaceName.toLowerCase().indexOf('wireless') >= 0 || ifaceName.toLowerCase().indexOf('wi-fi') >= 0 || ifaceName.toLowerCase().indexOf('wifi') >= 0) {
                   type = 'wireless';
@@ -895,7 +900,7 @@ function networkInterfaces(callback, rescan = true) {
               }
               const virtual = internal ? false : testVirtualNic(dev, ifaceName, mac);
               result.push({
-                iface: dev,
+                iface,
                 ifaceName,
                 ip4,
                 ip4subnet,


### PR DESCRIPTION
For Windows interfaces that don't show up in os.networkInterfaces() don't have the correct iface, instead use the name of it. 

Added NetConnectionId in wmic nic query, which is the name windows shows on the control panel and task manager

Before (omitted other details)
[
  {
    iface: 'Ethernet 2',
    ifaceName: 'Surface Ethernet Adapter',
  },
  {
    iface: 'Marvell AVASTAR Wireless-AC Network Controller',
    ifaceName: 'Marvell AVASTAR Wireless-AC Network Controller',
  },
  {
    iface: 'Bluetooth Device (Personal Area Network)',
    ifaceName: 'Bluetooth Device (Personal Area Network)',
  }
]

After
[
  {
    iface: 'Ethernet 2',
    ifaceName: 'Surface Ethernet Adapter',
  },
  {
    iface: 'WiFi',
    ifaceName: 'Marvell AVASTAR Wireless-AC Network Controller',
  },
  {
    iface: 'Bluetooth Network Connection',
    ifaceName: 'Bluetooth Device (Personal Area Network)',
  }
]