### PR TITLE
compare graphics buss address in lower case

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -728,7 +728,7 @@ function graphics(callback) {
               const nvidiaData = nvidiaDevices();
               // needs to be rewritten ... using no spread operators
               result.controllers = result.controllers.map((controller) => { // match by busAddress
-                return mergeControllerNvidia(controller, nvidiaData.find(({ pciBus }) => pciBus.endsWith(controller.busAddress)) || {});
+                return mergeControllerNvidia(controller, nvidiaData.find(({ pciBus }) => pciBus.toLowerCase().endsWith(controller.busAddress.toLowerCase())) || {});
               });
             }
             let cmd = 'clinfo --raw';


### PR DESCRIPTION
Because nvidia-smi reports buss address in upper case, the comparison never matches and the result of find is always {}.
Since I was not sure if this only happens in my version of nvidia-smi, I suggest to safely compare lower case version of both buss addresses.