### PR TITLE
fix (windows) networkInterfaces: match first nic by mac address

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -874,16 +874,15 @@ function networkInterfaces(callback, rescan = true) {
 
 
                 dnsSuffix = getWindowsIfaceDNSsuffix(dnsSuffixes.ifaces, dev);
-                nics.forEach(detail => {
-                  if (detail.mac === mac) {
-                    iface = detail.iface || iface;
-                    ifaceName = detail.name;
-                    dhcp = detail.dhcp;
-                    operstate = detail.operstate;
-                    speed = detail.speed;
-                    type = detail.type;
-                  }
-                });
+                let nicByMac = nics.find(x => x.mac === mac);
+                if (nicByMac) {
+                  iface = nicByMac.iface || iface;
+                  ifaceName = nicByMac.name;
+                  dhcp = nicByMac.dhcp;
+                  operstate = nicByMac.operstate;
+                  speed = nicByMac.speed;
+                  type = nicByMac.type;
+                }
 
                 if (dev.toLowerCase().indexOf('wlan') >= 0 || ifaceName.toLowerCase().indexOf('wlan') >= 0 || ifaceName.toLowerCase().indexOf('802.11n') >= 0 || ifaceName.toLowerCase().indexOf('wireless') >= 0 || ifaceName.toLowerCase().indexOf('wi-fi') >= 0 || ifaceName.toLowerCase().indexOf('wifi') >= 0) {
                   type = 'wireless';


### PR DESCRIPTION
Hi Sebastian,

windows may have multiple network interfaces with same MAC-Address, this usually are the virtual adapters. 

`wmic nic get Name,NetConnectionID,MACAddress`

```
MACAddress         Name                                                                   NetConnectionID             
                   Microsoft Kernel Debug Network Adapter                                                             
7C:B2:7D:7D:D5:8E  Killer(R) Wireless-AC 1550i Wireless Network Adapter (9560NGW) 160MHz  Wi-Fi                       
80:FA:5B:82:2E:96  Realtek PCIe GbE Family Controller                                     Ethernet                    
7C:B2:7D:7D:D5:8F  Microsoft Wi-Fi Direct Virtual Adapter                                                             
                   WAN Miniport (SSTP)                                                                                
                   WAN Miniport (IKEv2)                                                                               
                   WAN Miniport (L2TP)                                                                                
                   WAN Miniport (PPTP)                                                                                
                   WAN Miniport (PPPOE)                                                                               
32:34:20:52:41:53  WAN Miniport (IP)                                                                                  
32:C8:20:52:41:53  WAN Miniport (IPv6)                                                                                
34:6C:20:52:41:53  WAN Miniport (Network Monitor)                                                                     
7E:B2:7D:7D:D5:8E  Microsoft Wi-Fi Direct Virtual Adapter #2                                                          
                   Bluetooth Device (Personal Area Network)                                                           
                   ExpressVPN TAP Adapter                                                 Ethernet 2                  
                   Microsoft Wi-Fi Direct Virtual Adapter                                                             
                   ExpressVPN Wintun Driver                                               Local Area Connection       
                   Hyper-V Virtual Switch Extension Adapter                                                           
00:15:5D:FB:2A:F7  Hyper-V Virtual Ethernet Adapter                                       vEthernet (Default Switch)  
                   Hyper-V Virtual Switch Extension Adapter                                                           
7C:B2:7D:7D:D5:8E  Hyper-V Virtual Ethernet Adapter #2                                    vEthernet (External)        
```

_See the `7C:B2:7D:7D:D5:8E`_

So, just matching `if (detail.mac === mac)` in `forEach` causes to pick the last incorrect `vEthernet (External)` iface, but `os.networkInterfaces()` returns correct `Wi-Fi` iface. There for the interfaces are not matched and `networkStats` returns all zeros.

In the PR we pick the first interface matched by mac. At least such approach is more correct.

Best, Alex