### PR TITLE
Get default network gateway  on mac OS with an active VPN

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -1503,26 +1503,26 @@ function networkGatewayDefault(callback) {
         try {
           exec(cmd, { maxBuffer: 1024 * 20000 }, function (error, stdout) {
             if (!error) {
-              let lines = stdout.toString().split('\n').map(line => line.trim());
+              const lines = stdout.toString().split('\n').map(line => line.trim());
               result = util.getValue(lines, 'gateway');
-              if (!result) {
-                cmd = 'netstat -rn | awk \'/default/ {print $2}\'';
-                exec(cmd, { maxBuffer: 1024 * 20000 }, function (error, stdout) {
-                  lines = stdout.toString().split('\n').map(line => line.trim());
-                  result = lines.find(line => (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(line)));
-                  if (callback) {
-                    callback(result);
-                  }
-                  resolve(result);
-                });
-              } else {
+            }
+            if (!result) {
+              cmd = 'netstat -rn | awk \'/default/ {print $2}\'';
+              exec(cmd, { maxBuffer: 1024 * 20000 }, function (error, stdout) {
+                const lines = stdout.toString().split('\n').map(line => line.trim());
+                result = lines.find(line => (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(line)));
                 if (callback) {
                   callback(result);
                 }
                 resolve(result);
+              });
+            } else {
+              if (callback) {
+                callback(result);
               }
+              resolve(result);
             }
-            });
+          });
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/lib/network.js
+++ b/lib/network.js
@@ -1505,17 +1505,24 @@ function networkGatewayDefault(callback) {
             if (!error) {
               let lines = stdout.toString().split('\n').map(line => line.trim());
               result = util.getValue(lines, 'gateway');
-              if (callback) {
-                callback(result);
+              if (!result) {
+                cmd = 'netstat -rn | awk \'/default/ {print $2}\'';
+                exec(cmd, { maxBuffer: 1024 * 20000 }, function (error, stdout) {
+                  lines = stdout.toString().split('\n').map(line => line.trim());
+                  result = lines.find(line => (/^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/.test(line)));
+                  if (callback) {
+                    callback(result);
+                  }
+                  resolve(result);
+                });
+              } else {
+                if (callback) {
+                  callback(result);
+                }
+                resolve(result);
               }
-              resolve(result);
-            } else {
-              if (callback) {
-                callback(result);
-              }
-              resolve(result);
             }
-          });
+            });
         } catch (e) {
           if (callback) { callback(result); }
           resolve(result);

--- a/test/networktest.js
+++ b/test/networktest.js
@@ -1,8 +1,0 @@
-const network = require('../lib/network');
-
-
-async function getNetwork() {
-    console.log(await network.networkGatewayDefault());
-}
-
-getNetwork();

--- a/test/networktest.js
+++ b/test/networktest.js
@@ -1,0 +1,8 @@
+const network = require('../lib/network');
+
+
+async function getNetwork() {
+    console.log(await network.networkGatewayDefault());
+}
+
+getNetwork();


### PR DESCRIPTION
When mac OS is connected to a VPN the current command to get the default network gateway cannot get the gateway IP address 
![image](https://user-images.githubusercontent.com/70594665/117045832-97d0ff00-acd5-11eb-9496-4713ae6f0f45.png)

So this PR use this command `netstat -rn | awk \'/default/ {print $2}\'` as fallback.

Tested in: 
- macOS 10.13.6 (High Sierra)
- macOS 11.3 (Big Sur)