### PR TITLE
Fix wrong VM detection

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -159,7 +159,7 @@ function system(callback) {
             result.model = 'Docker Container';
           }
           try {
-            const stdout = execSync('dmesg 2>/dev/null | grep -iE "virtual|hypervisor" | grep -iE "vmware|qemu|kvm|xen"');
+            const stdout = execSync('dmesg 2>/dev/null | grep -iE "virtual|hypervisor" | grep -iE "vmware|qemu|kvm|xen" | grep -vi "Nested Virtualization"');
             // detect virtual machines
             let lines = stdout.toString().split('\n');
             if (lines.length > 0) {


### PR DESCRIPTION
The program was detecting VM on a regular computer. After some research I have found out that it was "kvm: Nested Virtualization enabled". I fixed it by removing lines with "Nested Virtualization enabled". Closes #532.