### PR TITLE
fix: battery designed capacity on windows

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -256,7 +256,7 @@ module.exports = function (callback) {
                       {
                         hasBattery: parsed.hasBattery,
                         maxCapacity: parsed.maxCapacity,
-                        designedCapacity: parsed.designCapacity,
+                        designedCapacity: parsed.designedCapacity,
                         voltage: parsed.voltage,
                         capacityUnit: parsed.capacityUnit,
                         percent: parsed.percent,

--- a/lib/battery.js
+++ b/lib/battery.js
@@ -46,7 +46,7 @@ function parseWinBatteryPart(lines, designCapacity, fullChargeCapacity) {
     result.status = statusValue;
     result.hasBattery = true;
     result.maxCapacity = fullChargeCapacity || parseInt(util.getValue(lines, 'DesignCapacity', '=') || 0);
-    result.designCapacity = parseInt(util.getValue(lines, 'DesignCapacity', '=') || designCapacity);
+    result.designedCapacity = parseInt(util.getValue(lines, 'DesignCapacity', '=') || designCapacity);
     result.voltage = parseInt(util.getValue(lines, 'DesignVoltage', '=') || 0) / 1000.0;
     result.capacityUnit = 'mWh';
     result.percent = parseInt(util.getValue(lines, 'EstimatedChargeRemaining', '=') || 0);
@@ -220,8 +220,8 @@ module.exports = function (callback) {
               // let parts = data.results[0].split(/\n\s*\n/);
               let parts = data.results[0].split('\r\n');
               let batteries = [];
+              const hasValue = value => /\S/.test(value);
               for (let i = 0; i < parts.length; i++) {
-                const hasValue = value => /\S/.test(value);
                 if (hasValue(parts[i]) && (!batteries.length || !hasValue(parts[i - 1]))) {
                   batteries.push([]);
                 }
@@ -236,13 +236,13 @@ module.exports = function (callback) {
                 let additionalBatteries = [];
                 for (let i = 0; i < batteries.length; i++) {
                   let lines = batteries[i];
-                  const designCapacity = designCapacities && designCapacities.length >= (i + 1) && designCapacities[i] ? util.toInt(designCapacities[i]) : 0;
+                  const designedCapacity = designCapacities && designCapacities.length >= (i + 1) && designCapacities[i] ? util.toInt(designCapacities[i]) : 0;
                   const fullChargeCapacity = fullChargeCapacities && fullChargeCapacities.length >= (i + 1) && fullChargeCapacities[i] ? util.toInt(fullChargeCapacities[i]) : 0;
-                  const parsed = parseWinBatteryPart(lines, designCapacity, fullChargeCapacity);
+                  const parsed = parseWinBatteryPart(lines, designedCapacity, fullChargeCapacity);
                   if (!first && parsed.status > 0 && parsed.status !== 10) {
                     result.hasBattery = parsed.hasBattery;
                     result.maxCapacity = parsed.maxCapacity;
-                    result.designCapacity = parsed.designCapacity;
+                    result.designedCapacity = parsed.designedCapacity;
                     result.voltage = parsed.voltage;
                     result.capacityUnit = parsed.capacityUnit;
                     result.percent = parsed.percent;
@@ -256,7 +256,7 @@ module.exports = function (callback) {
                       {
                         hasBattery: parsed.hasBattery,
                         maxCapacity: parsed.maxCapacity,
-                        designCapacity: parsed.designCapacity,
+                        designedCapacity: parsed.designCapacity,
                         voltage: parsed.voltage,
                         capacityUnit: parsed.capacityUnit,
                         percent: parsed.percent,


### PR DESCRIPTION
Hi @sebhildebrandt!

 I noticed at some point a wrong key name was introduced. API provides `designedCapacity` and windows fn was adding a `designCapacity` key. Quite an important fix :)  

(I also moved a helper function out of the loop for optimization purposes - we don't need to create it on each iteration.)