### PR TITLE
fix uefi always returning false

### DIFF
--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -397,6 +397,7 @@ function isUefiWindows() {
               }
               resolve(false);
             });
+            return;
           }
           resolve(false);
         });


### PR DESCRIPTION
fix uefi always returning false
it appears to be carrying on and returning the last false, rather than waiting for the exec to finish and return that instead