### PR TITLE
fix: linux battery capacity

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -90,19 +90,26 @@ module.exports = function (callback) {
         } else if (fs.existsSync('/sys/class/power_supply/BAT0/uevent')) {
           battery_path = '/sys/class/power_supply/BAT0/';
         }
+
+        let acConnected = false;
+        if (fs.existsSync('/sys/class/power_supply/AC/online')) {
+          const file = fs.readFileSync('/sys/class/power_supply/AC/online');
+          acConnected = file.toString().trim() === '1';
+        }
+
         if (battery_path) {
           fs.readFile(battery_path + 'uevent', function (error, stdout) {
             if (!error) {
               let lines = stdout.toString().split('\n');
 
               result.isCharging = (util.getValue(lines, 'POWER_SUPPLY_STATUS', '=').toLowerCase() === 'charging');
-              result.acConnected = result.isCharging;
+              result.acConnected = acConnected || result.isCharging;
               result.voltage = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_VOLTAGE_NOW', '='), 10) / 1000000.0;
               result.capacityUnit = result.voltage ? 'mWh' : 'mAh';
               result.cycleCount = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CYCLE_COUNT', '='), 10);
-              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0 / (result.voltage || 1));
-              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0 / (result.voltage || 1)) | result.maxcapacity;
-              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0 / (result.voltage || 1));
+              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0);
+              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0);
+              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0);
               if (!result.maxCapacity) {
                 result.maxCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL', '='), 10) / 1000.0;
                 result.designedCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL_DESIGN', '='), 10) / 1000.0 | result.maxCapacity;

--- a/lib/battery.js
+++ b/lib/battery.js
@@ -92,8 +92,15 @@ module.exports = function (callback) {
         }
 
         let acConnected = false;
+        let acPath = '';
         if (fs.existsSync('/sys/class/power_supply/AC/online')) {
-          const file = fs.readFileSync('/sys/class/power_supply/AC/online');
+          acPath = '/sys/class/power_supply/AC/online';
+        } else if (fs.existsSync('/sys/class/power_supply/AC0/online')) {
+          acPath = '/sys/class/power_supply/AC0/online';
+        }
+
+        if (acPath) {
+          const file = fs.readFileSync(acPath);
           acConnected = file.toString().trim() === '1';
         }
 

--- a/lib/battery.js
+++ b/lib/battery.js
@@ -107,9 +107,9 @@ module.exports = function (callback) {
               result.voltage = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_VOLTAGE_NOW', '='), 10) / 1000000.0;
               result.capacityUnit = result.voltage ? 'mWh' : 'mAh';
               result.cycleCount = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CYCLE_COUNT', '='), 10);
-              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0);
-              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0);
-              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0);
+              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0 * (result.voltage | 1));
+              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0 * (result.voltage | 1));
+              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0 * (result.voltage | 1));
               if (!result.maxCapacity) {
                 result.maxCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL', '='), 10) / 1000.0;
                 result.designedCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL_DESIGN', '='), 10) / 1000.0 | result.maxCapacity;

--- a/lib/battery.js
+++ b/lib/battery.js
@@ -107,9 +107,9 @@ module.exports = function (callback) {
               result.voltage = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_VOLTAGE_NOW', '='), 10) / 1000000.0;
               result.capacityUnit = result.voltage ? 'mWh' : 'mAh';
               result.cycleCount = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CYCLE_COUNT', '='), 10);
-              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0 * (result.voltage | 1));
-              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0 * (result.voltage | 1));
-              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0 * (result.voltage | 1));
+              result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL', '='), 10) / 1000.0 * (result.voltage || 1));
+              result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_FULL_DESIGN', '='), 10) / 1000.0 * (result.voltage || 1));
+              result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_CHARGE_NOW', '='), 10) / 1000.0 * (result.voltage || 1));
               if (!result.maxCapacity) {
                 result.maxCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL', '='), 10) / 1000.0;
                 result.designedCapacity = parseInt('0' + util.getValue(lines, 'POWER_SUPPLY_ENERGY_FULL_DESIGN', '='), 10) / 1000.0 | result.maxCapacity;

--- a/lib/util.js
+++ b/lib/util.js
@@ -112,7 +112,7 @@ function getValue(lines, property, separator, trimmed) {
     if (trimmed) {
       line = line.trim();
     }
-    if (line.match(property + separator)) {
+    if (line.startsWith(property) && line.match(property + separator)) {
       const parts = trimmed ? lines[i].trim().split(separator) : lines[i].split(separator);
       if (parts.length >= 2) {
         parts.shift();

--- a/lib/util.js
+++ b/lib/util.js
@@ -112,7 +112,7 @@ function getValue(lines, property, separator, trimmed) {
     if (trimmed) {
       line = line.trim();
     }
-    if (line.startsWith(property)) {
+    if (line.match(property + separator)) {
       const parts = trimmed ? lines[i].trim().split(separator) : lines[i].split(separator);
       if (parts.length >= 2) {
         parts.shift();


### PR DESCRIPTION
Fixes for #569 

Important notes:
1.  From my tests `getValue` works correctly in terms of getting correct battery values on all three platforms. But I'm fairly sure it's used in other places that I didn't check.
2. I've found that on Manjaro and Ubuntu there is a way to get correct AC status instead of relying on isCharging which turns acConnected false when charging stops which is not true. I've implemented this as a `readFileSync` to not mess much with the logic you have there, but if you want this probably can be updated to some promises or some callback chain. I don't think this `sync` messes up there a lot, but up to you :)

Results (with correct `acConnected` state while `isCharging false` as well): 

![xx](https://user-images.githubusercontent.com/13939486/128503235-7a784579-7e6b-4247-857a-c71cc25b8927.png)
