### PR TITLE
Fix wifiConnections & wifiInterfaces in Windows.

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -565,7 +565,7 @@ function wifiConnections(callback) {
       } else if (_windows) {
         let cmd = 'netsh wlan show interfaces';
         exec(cmd, util.execOptsWin, function (error, stdout) {
-          const parts = stdout.toString().split(':\r\n\r\n');
+          const parts = stdout.toString().split(': \r\n\r\n');
           parts.shift();
           parts.forEach(part => {
             const lines = part.split('\r\n');
@@ -661,7 +661,7 @@ function wifiInterfaces(callback) {
       } else if (_windows) {
         let cmd = 'netsh wlan show interfaces';
         exec(cmd, util.execOptsWin, function (error, stdout) {
-          const parts = stdout.toString().split(':\r\n\r\n');
+          const parts = stdout.toString().split(': \r\n\r\n');
           parts.shift();
           parts.forEach(part => {
             const lines = part.split('\r\n');


### PR DESCRIPTION
Hello. This PR fix wifiConnections() and wifiInterfaces() from returning empty always in Windows.

### Tested locally in a Windows Machine:
```js
// OS
{
  platform: 'win32',
  distro: 'Microsoft Windows 10 Pro',
  release: '10.0.19042',
  codename: '',
  kernel: '10.0.19042',
  arch: 'x64',
  build: '19042',
  servicepack: '0.0',
  uefi: true,
  hypervisor: false,
  remoteSession: false
}
// System
{
  manufacturer: 'Microsoft Corporation',
  model: 'Surface Pro',
  version: '124000000000000000000000D:0B:09F:5C:09P:38S:01E:0',
  virtual: false
}
```
#### Tested against Node v12, v14 & v16.

### I was receiving the following stdout output when executing `netsh wlan show interfaces`:
```txt
// console.log([stdout]):
 [
  '\r\n' +
    'There is 1 interface on the system: \r\n' +
    '\r\n' +
    '    Name                   : Wi-Fi\r\n' +
    '    Description            : Marvell AVASTAR Wireless-AC Network Controller\r\n' +
    '    GUID                   : 1234567a-4a20-42a0-66a6-420a01d66b6a\r\n' +
    '    Physical address       : aa:420:69:a6:aa:69\r\n' +
    '    State                  : connected\r\n' +
    '    SSID                   : MEO-7C14A5\r\n' +
    '    BSSID                  : 42:aa:06:aa:96:f9\r\n' +
    '    Network type           : Infrastructure\r\n' +
    '    Radio type             : 802.11n\r\n' +
    '    Authentication         : WPA2-Personal\r\n' +
    '    Cipher                 : CCMP\r\n' +
    '    Connection mode        : Auto Connect\r\n' +
    '    Channel                : 2\r\n' +
    '    Receive rate (Mbps)    : 144\r\n' +
    '    Transmit rate (Mbps)   : 144\r\n' +
    '    Signal                 : 99% \r\n' +
    '    Profile                : MEO-7C14A5 \r\n' +
    '\r\n' +
    '    Hosted network status  : Not available\r\n' +
    '\r\n'
]
```

### Previous to this fix, running `npm test`:
```txt
┌────────────────────────────────────────────────┐
│  WIFI Interfaces                      v: 5.8.7 │
└────────────────────────────────────────────────┘
[]
Time to complete: 353.011ms
```
```txt
┌────────────────────────────────────────────────┐
│  WIFI Connections                     v: 5.8.7 │
└────────────────────────────────────────────────┘
[]
Time to complete: 384.932ms
```

### With this fix, running `npm test`:
```txt
┌────────────────────────────────────────────────┐
│  WIFI Interfaces                      v: 5.8.7 │
└────────────────────────────────────────────────┘
[
  {
    id: '1234567a-4a20-42a0-66a6-420a01d66b6a',
    iface: 'Wi-Fi',
    model: 'Marvell AVASTAR Wireless-AC Network Controller',
    vendor: 'Marvel',
    mac: 'ab:42:06:c9:de:69'
  }
]
Time to complete: 457.958ms
```
```txt
┌────────────────────────────────────────────────┐
│  WIFI Connections                     v: 5.8.7 │
└────────────────────────────────────────────────┘
[
  {
    id: '1234567a-4a20-42a0-66a6-420a01d66b6a',
    iface: 'Wi-Fi',
    model: 'Marvell AVASTAR Wireless-AC Network Controller',
    ssid: 'MEO-7C14A5',
    bssid: '42:aa:06:aa:96:f9',
    channel: 2,
    frequency: 2417,
    type: '802.11n',
    security: 'WPA2-Personal',
    signalLevel: '99%',
    txRate: 144
  }
]
Time to complete: 519.571ms
```

fixes #525 