### PR TITLE
improve wifiNetworks detection (win)

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -417,28 +417,35 @@ function wifiNetworks(callback) {
         let cmd = 'chcp 65001 && netsh wlan show networks mode=Bssid';
         exec(cmd, util.execOptsWin, function (error, stdout) {
 
-          const parts = stdout.toString('utf8').split(os.EOL + os.EOL + 'SSID ');
-          parts.shift();
+          const ssidParts = stdout.toString('utf8').split(os.EOL + os.EOL + 'SSID ');
+          ssidParts.shift();
 
-          parts.forEach(part => {
-            const lines = part.split(os.EOL);
-            if (lines && lines.length >= 8 && lines[0].indexOf(':') >= 0) {
-              let bssid = lines[4].split(':');
-              bssid.shift();
-              bssid = bssid.join(':').trim().toLowerCase();
-              const channel = lines[7].split(':').pop().trim();
-              const quality = lines[5].split(':').pop().trim();
-              result.push({
-                ssid: lines[0].split(':').pop().trim(),
-                bssid,
-                mode: '',
-                channel: channel ? parseInt(channel, 10) : null,
-                frequency: wifiFrequencyFromChannel(channel),
-                signalLevel: wifiDBFromQuality(quality),
-                quality: quality ? parseInt(quality, 10) : null,
-                security: [lines[2].split(':').pop().trim()],
-                wpaFlags: [lines[3].split(':').pop().trim()],
-                rsnFlags: []
+          ssidParts.forEach(ssidPart => {
+            const ssidLines = ssidPart.split(os.EOL);
+            if (ssidLines && ssidLines.length >= 8 && ssidLines[0].indexOf(':') >= 0) {
+              const bssidsParts = ssidPart.split('BSSID ');
+              bssidsParts.shift();
+
+              bssidsParts.forEach((bssidPart) => {
+                const bssidLines = bssidPart.split(os.EOL);
+                const bssidLine = bssidLines[0].split(':');
+                bssidLine.shift();
+                const bssid = bssidLine.join(':').trim().toLowerCase();
+                const channel = bssidLines[3].split(':').pop().trim();
+                const quality = bssidLines[1].split(':').pop().trim();
+
+                result.push({
+                  ssid: ssidLines[0].split(':').pop().trim(),
+                  bssid,
+                  mode: '',
+                  channel: channel ? parseInt(channel, 10) : null,
+                  frequency: wifiFrequencyFromChannel(channel),
+                  signalLevel: wifiDBFromQuality(quality),
+                  quality: quality ? parseInt(quality, 10) : null,
+                  security: [ssidLines[2].split(':').pop().trim()],
+                  wpaFlags: [ssidLines[3].split(':').pop().trim()],
+                  rsnFlags: []
+                });
               });
             }
           });


### PR DESCRIPTION
capable of identify multiple access points (BSSIDs) for the same Network(SSID).

### Tested locally in a Windows Machine:
```js
// OS
{
  platform: 'win32',
  distro: 'Microsoft Windows 10 Pro',
  release: '10.0.19042',
  codename: '',
  kernel: '10.0.19042',
  arch: 'x64',
  build: '19042',
  servicepack: '0.0',
  uefi: true,
  hypervisor: false,
  remoteSession: false
}
// System
{
  manufacturer: 'Microsoft Corporation',
  model: 'Surface Pro',
  version: '124000000000000000000000D:0B:09F:5C:09P:38S:01E:0',
  virtual: false
}
```
#### Tested against Node v12, v14 & v16.

### I was receiving the following stdout output when executing `netsh wlan show networks mode=Bssid`:
```txt
// console.log([stdout]):
[
  'Active code page: 65001\r\n' +
    ' \r\n' +
    'Interface name : Wi-Fi \r\n' +
    'There are 4 networks currently visible. \r\n' +
    '\r\n' +
    'SSID 1 : MEO-7C14A5\r\n' +
    '    Network type            : Infrastructure\r\n' +
    '    Authentication          : WPA2-Personal\r\n' +
    '    Encryption              : CCMP \r\n' +
    '    BSSID 1                 : 9c:97:26:7c:14:a5\r\n' +
    '         Signal             : 64%  \r\n' +
    '         Radio type         : 802.11n\r\n' +
    '         Channel            : 11 \r\n' +
    '         Basic rates (Mbps) : 1 2 5.5 11\r\n' +
    '         Other rates (Mbps) : 6 9 12 18 24 36 48 54\r\n' +
    '    BSSID 2                 : 28:ee:52:ef:78:f8\r\n' +
    '         Signal             : 100%  \r\n' +
    '         Radio type         : 802.11n\r\n' +
    '         Channel            : 2 \r\n' +
    '         Basic rates (Mbps) : 1 2 5.5 11\r\n' +
    '         Other rates (Mbps) : 6 9 12 18 24 36 48 54\r\n' +
    '\r\n' +
    'SSID 2 : MEO-WiFi\r\n' +
    '    Network type            : Infrastructure\r\n' +
    '    Authentication          : Open\r\n' +
    '    Encryption              : None \r\n' +
    '    BSSID 1                 : cc:19:a8:f6:63:62\r\n' +
    '         Signal             : 25%  \r\n' +
    '         Radio type         : 802.11n\r\n' +
    '         Channel            : 6 \r\n' +
    '         Basic rates (Mbps) : 1 2 5.5 11\r\n' +
    '         Other rates (Mbps) : 6 9 12 18 24 36 48 54\r\n' +
    '\r\n' +
    'SSID 3 : Thomson7343CA\r\n' +
    '    Network type            : Infrastructure\r\n' +
    '    Authentication          : WPA2-Personal\r\n' +
    '    Encryption              : CCMP \r\n' +
    '    BSSID 1                 : cc:19:a8:f6:63:60\r\n' +
    '         Signal             : 27%  \r\n' +
    '         Radio type         : 802.11n\r\n' +
    '         Channel            : 6 \r\n' +
    '         Basic rates (Mbps) : 1 2 5.5 11\r\n' +
    '         Other rates (Mbps) : 6 9 12 18 24 36 48 54\r\n' +
    '\r\n' +
    'SSID 4 : mobileDroid\r\n' +
    '    Network type            : Infrastructure\r\n' +
    '    Authentication          : WPA2-Personal\r\n' +
    '    Encryption              : CCMP \r\n' +
    '    BSSID 1                 : 40:0e:85:58:e5:9f\r\n' +
    '         Signal             : 100%  \r\n' +
    '         Radio type         : 802.11n\r\n' +
    '         Channel            : 6 \r\n' +
    '         Basic rates (Mbps) : 1 2 5.5 11\r\n' +
    '         Other rates (Mbps) : 6 9 12 18 24 36 48 54\r\n' +
    '\r\n'
]
```

### Previous to this fix, running `npm test`:
```txt
┌────────────────────────────────────────────────┐
│  WIFI Networks                        v: 5.8.7 │
└────────────────────────────────────────────────┘
[
  {
    ssid: 'MEO-7C14A5',
    bssid: '9c:97:26:7c:14:a5',
    mode: '',
    channel: 11,
    frequency: 2462,
    signalLevel: -73,
    quality: 54,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  },
  {
    ssid: 'MEO-WiFi',
    bssid: 'cc:19:a8:f6:63:62',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -86.5,
    quality: 27,
    security: [ 'Open' ],
    wpaFlags: [ 'None' ],
    rsnFlags: []
  },
  {
    ssid: 'Thomson7343CA',
    bssid: 'cc:19:a8:f6:63:60',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -83.5,
    quality: 33,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  },
  {
    ssid: 'mobileDroid',
    bssid: '40:0e:85:58:e5:9f',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -50,
    quality: 100,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  }
]

Time to complete: 531.086ms
```

### With this fix, running `npm test`:
```txt
┌────────────────────────────────────────────────┐
│  WIFI Networks                        v: 5.8.7 │
└────────────────────────────────────────────────┘
[
  {
    ssid: 'MEO-7C14A5',
    bssid: '9c:97:26:7c:14:a5',
    mode: '',
    channel: 11,
    frequency: 2462,
    signalLevel: -73,
    quality: 54,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  },
  {
    ssid: 'MEO-7C14A5',
    bssid: '28:ee:52:ef:78:f8',
    mode: '',
    channel: 2,
    frequency: 2417,
    signalLevel: -50,
    quality: 100,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  },
  {
    ssid: 'MEO-WiFi',
    bssid: 'cc:19:a8:f6:63:62',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -86.5,
    quality: 27,
    security: [ 'Open' ],
    wpaFlags: [ 'None' ],
    rsnFlags: []
  },
  {
    ssid: 'Thomson7343CA',
    bssid: 'cc:19:a8:f6:63:60',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -83.5,
    quality: 33,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  },
  {
    ssid: 'mobileDroid',
    bssid: '40:0e:85:58:e5:9f',
    mode: '',
    channel: 6,
    frequency: 2437,
    signalLevel: -50,
    quality: 100,
    security: [ 'WPA2-Personal' ],
    wpaFlags: [ 'CCMP' ],
    rsnFlags: []
  }
]

Time to complete: 531.086ms
```