### PR TITLE
fix situations where many BSSIDs share one SSID

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -446,6 +446,28 @@ function wifiNetworks(callback) {
                   wpaFlags: [ssidLines[3].split(':').pop().trim()],
                   rsnFlags: []
                 });
+                
+                let i = 10;
+                while (i + 6 <= lines.length) {
+                  let bssid = lines[i].split(':');
+                  bssid.shift();
+                  bssid = bssid.join(':').trim().toLowerCase();
+                  const channel = lines[i+3].split(':').pop().trim();
+                  const quality = lines[i+1].split(':').pop().trim();
+                  result.push({
+                    ssid: lines[0].split(':').pop().trim(),
+                    bssid,
+                    mode: '',
+                    channel: channel ? parseInt(channel, 10) : null,
+                    frequency: wifiFrequencyFromChannel(channel),
+                    signalLevel: wifiDBFromQuality(quality),
+                    quality: quality ? parseInt(quality, 10) : null,
+                    security: [lines[2].split(':').pop().trim()],
+                    wpaFlags: [lines[3].split(':').pop().trim()],
+                    rsnFlags: []
+                  });
+                  i += 6;
+                }
               });
             }
           });


### PR DESCRIPTION
in company, many APs (one AP, one BSSID) share a single SSID, so we must enumerate all BSSIDs
(在公司里面，一般一个SSID会由多个AP提供服务，每个AP都包含一个独立的BSSID，这样就可以把所有的BSSID都枚举出来)