### PR TITLE
Don't call sysctl -a

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -198,7 +198,7 @@ function mem(callback) {
         });
       }
       if (_freebsd || _openbsd || _netbsd) {
-        exec('/sbin/sysctl -a 2>/dev/null | grep -E "hw.realmem|hw.physmem|vm.stats.vm.v_page_count|vm.stats.vm.v_wire_count|vm.stats.vm.v_active_count|vm.stats.vm.v_inactive_count|vm.stats.vm.v_cache_count|vm.stats.vm.v_free_count|vm.stats.vm.v_page_size"', function (error, stdout) {
+        exec('/sbin/sysctl hw.realmem hw.physmem vm.stats.vm.v_page_count vm.stats.vm.v_wire_count vm.stats.vm.v_active_count vm.stats.vm.v_inactive_count vm.stats.vm.v_cache_count vm.stats.vm.v_free_count vm.stats.vm.v_page_size 2>/dev/null"', function (error, stdout) {
           if (!error) {
             let lines = stdout.toString().split('\n');
             const pagesize = parseInt(util.getValue(lines, 'vm.stats.vm.v_page_size'), 10);


### PR DESCRIPTION
Running sysctl -a takes multiple seconds and returns ~17k lines, while
requesting only the required 9 lines is much faster.

Also, page size (vm.stats.vm.v_page_size) is unlikely to change at run
time, further work could be done there.