### PR TITLE
fix: tests not building files before running

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,4 +30,5 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      - run: npm run build
       - run: node test/ci.js


### PR DESCRIPTION
This allows tests to work on the v6 branch.