### PR TITLE
speedup windows services and incorrect started compare

### DIFF
--- a/lib/processes.js
+++ b/lib/processes.js
@@ -324,7 +324,16 @@ function services(srv, callback) {
         }
         if (_windows) {
           try {
-            util.powerShell('Get-WmiObject Win32_Service | fl *').then((stdout, error) => {
+            let wincommand = "Get-WmiObject Win32_Service ";
+            if (srvs[0] !== '*') {
+              wincommand += '-Filter "';
+              for (let i = 0; i < srvs.length; i++) {
+                wincommand += `Name='${srvs[i]}' or `;
+              }
+              wincommand = `${wincommand.slice(0,-4)}"`;
+            }
+            wincommand += '| fl *';
+            util.powerShell(wincommand).then((stdout, error) => {
               if (!error) {
                 let serviceSections = stdout.split(/\n\s*\n/);
                 for (let i = 0; i < serviceSections.length; i++) {
@@ -338,7 +347,7 @@ function services(srv, callback) {
                     if (srvString === '*' || srvs.indexOf(srvName) >= 0 || srvs.indexOf(srvCaption) >= 0) {
                       result.push({
                         name: srvName,
-                        running: (started === 'TRUE'),
+                        running: (started.toLowerCase() === 'true'),
                         startmode: startMode,
                         pids: [pid],
                         cpu: 0,

--- a/lib/processes.js
+++ b/lib/processes.js
@@ -324,15 +324,15 @@ function services(srv, callback) {
         }
         if (_windows) {
           try {
-            let wincommand = "Get-WmiObject Win32_Service ";
+            let wincommand = "Get-WmiObject Win32_Service";
             if (srvs[0] !== '*') {
-              wincommand += '-Filter "';
+              wincommand += ' -Filter "';
               for (let i = 0; i < srvs.length; i++) {
                 wincommand += `Name='${srvs[i]}' or `;
               }
               wincommand = `${wincommand.slice(0,-4)}"`;
             }
-            wincommand += '| fl *';
+            wincommand += ' | fl *';
             util.powerShell(wincommand).then((stdout, error) => {
               if (!error) {
                 let serviceSections = stdout.split(/\n\s*\n/);


### PR DESCRIPTION
speed-up windows services lookup time for single services
(increased from 10 seconds for checking 2 services to 1 second)
also fix incorrect started compare
(my machine kept returning started as `True` not `TRUE` so convert it to lowercase then compare