### PR TITLE
Update Battery MaxCapacity

### DIFF
--- a/lib/battery.js
+++ b/lib/battery.js
@@ -184,7 +184,7 @@ module.exports = function (callback) {
             result.cycleCount = parseInt('0' + util.getValue(lines, 'cyclecount', '='), 10);
             result.voltage = parseInt('0' + util.getValue(lines, 'voltage', '='), 10) / 1000.0;
             result.capacityUnit = result.voltage ? 'mWh' : 'mAh';
-            result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'maxcapacity', '='), 10) * (result.voltage || 1));
+            result.maxCapacity = Math.round(parseInt('0' + util.getValue(lines, 'applerawmaxcapacity', '='), 10) * (result.voltage || 1));
             result.currentCapacity = Math.round(parseInt('0' + util.getValue(lines, 'currentcapacity', '='), 10) * (result.voltage || 1));
             result.designedCapacity = Math.round(parseInt('0' + util.getValue(lines, 'DesignCapacity', '='), 10) * (result.voltage || 1));
             result.manufacturer = 'Apple';


### PR DESCRIPTION
To be compatible and return the expected value on Mac OS Monterey & new Apple M1 units , along with preserving the backward compatibility.