### PR TITLE
Docs: Fix typo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -350,7 +350,7 @@
       <div class="row">
         <div class="col-12 sectionheader index">
           <div class="title-small">Issues</div>
-          <div class="text"><span class="warning">Security issues:</span> We highly recomment to have a look at our <a href="security.html">security advisories</a></div>
+          <div class="text"><span class="warning">Security issues:</span> We highly recommend to have a look at our <a href="security.html">security advisories</a></div>
           <div class="text"><span class="bold">Having an issue</span>: If you run into problems, please check out <a href="issues.html">known issues page</a> first.<br>If you still have problems, please feel free to open an issue on our <a href="https://github.com/sebhildebrandt/systeminformation/issues">github page</a></div>
         </div>
       </div>


### PR DESCRIPTION
# Typo fix

While I was reading through the landing page of [systeminformation.io](https://systeminformation.io/) I noticed a little typo what I would like to fix with this pr. :)