### PR TITLE
fix: Fixing a potential `race condition` and possibly memory leak in "powerShellStart"

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -396,6 +396,17 @@ function powerShellProceedResults(data) {
 }
 
 function powerShellStart() {
+  // Reuse existing persisted process, if one is available
+  if (_psPersistent && _psChild && _psChild.pid){
+    return;
+  }
+
+  // If somehow _psPersistent is not in sync with _psChild,
+  // just kill it and start a new one.
+  if (!_psPersistent && _psChild && _psChild.pid) {
+    powerShellRelease();
+  }
+
   _psChild = spawn('powershell.exe', ['-NoLogo', '-InputFormat', 'Text', '-NoExit', '-Command', '-'], {
     stdio: 'pipe',
     windowsHide: true,
@@ -403,25 +414,24 @@ function powerShellStart() {
     encoding: 'UTF-8',
     env: util._extend({}, process.env, { LANG: 'en_US.UTF-8' })
   });
-  if (_psChild && _psChild.pid) {
-    _psPersistent = true;
-    _psChild.stdout.on('data', function (data) {
-      _psResult = _psResult + data.toString('utf8');
-      if (data.indexOf(_psCmdSeperator) >= 0) {
-        powerShellProceedResults(_psResult);
-        _psResult = '';
-      }
-    });
-    _psChild.stderr.on('data', function () {
-      powerShellProceedResults(_psResult + _psError);
-    });
-    _psChild.on('error', function () {
-      powerShellProceedResults(_psResult + _psError);
-    });
-    _psChild.on('close', function () {
-      _psChild.kill();
-    });
-  }
+
+  _psPersistent = true;
+  _psChild.stdout.on('data', function (data) {
+    _psResult = _psResult + data.toString('utf8');
+    if (data.indexOf(_psCmdSeperator) >= 0) {
+      powerShellProceedResults(_psResult);
+      _psResult = '';
+    }
+  });
+  _psChild.stderr.on('data', function () {
+    powerShellProceedResults(_psResult + _psError);
+  });
+  _psChild.on('error', function () {
+    powerShellProceedResults(_psResult + _psError);
+  });
+  _psChild.on('close', function () {
+    _psChild.kill();
+  });
 }
 
 function powerShellRelease() {


### PR DESCRIPTION
We've been use `powerShellStart` and `powerShellRelease` in our project to minimise the number "PowerShell" processes created by SystemInformation in order to work around #626.

However, we've **noticed a couple of potential problems**, when `powerShellStart` are called multiple times, before `powerShellRelease` is called.

**Imagine the following scenario:**
1. function 1 calls `si.powerShellStart()` followed by `si.system(cb)` (or the promise version). It'll call `si.powerShellRelease` once it gets the response in the callback.
2. function 2 makes similar calls `si.powerShellStart()` followed by `si.os(cb)`.

**There are a couple of issues here:**

1. There's a chance that the call by function 2 could end up **creating a new "PowerShell" process**, which is not desirable, since creating "PowerShell" processes are expensive operation. It is also unnecessary to create the second "PowerShell" process, since function 2 should be able to just "reuse" the same "PowerShell" created by function 1.
2. The "PowerShell" process created by function 1 now becomes an "**orphan**", because `_psChild` is global therefore it's overwritten by the one created by function 2. The callback of function 1 may never be able to release it (hence possible memory leak), where the "PowerShell" process created by function 2 are released twice.

This commit changes `powerShellStart` function so that it first checks if a `persisted` "PowerShell" process already existed, and just reuse it if one is available.