### PR TITLE
graphics(): guard use of empty nvidiaData

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -720,10 +720,12 @@ function graphics(callback) {
               let lines = stdout.toString().split('\n');
               result.controllers = parseLinesLinuxControllers(lines);
               const nvidiaData = nvidiaDevices();
-              // needs to be rewritten ... using no spread operators
-              result.controllers = result.controllers.map((controller) => { // match by busAddress
-                return mergeControllerNvidia(controller, nvidiaData.find((contr) => contr.pciBus.toLowerCase().endsWith(controller.busAddress.toLowerCase())) || {});
-              });
+              if (nvidiaData[0] !== undefined) {
+                // needs to be rewritten ... using no spread operators
+                result.controllers = result.controllers.map((controller) => { // match by busAddress
+                  return mergeControllerNvidia(controller, nvidiaData.find((contr) => contr.pciBus.toLowerCase().endsWith(controller.busAddress.toLowerCase())) || {});
+                });
+              }
             }
             let cmd = 'clinfo --raw';
             exec(cmd, function (error, stdout) {


### PR DESCRIPTION
Fixes #706 

With this, the test code in #706 no longer errors out and now produces output. However this is my first time using this module so I am not sure if my fix has produced valid output (see below).

Also still not sure why no one else seems to have reported any issues like #706... surely I can't be the only one with an AMD GPU.

```sh
>node testgpu.ts
{
  controllers: [
    {
      vendor: 'Intel Corporation',
      model: 'Device 4682 ',
      bus: 'Onboard',
      busAddress: '00:02.0',
      vram: 256,
      vramDynamic: false,
      pciID: ''
    },
    {
      vendor: 'Advanced Micro Devices, Inc. [AMD/ATI]',
      model: 'Ellesmere [Radeon RX 470/480/570/570X/580/580X/590]',
      bus: 'Onboard',
      busAddress: '01:00.0',
      vram: 256,
      vramDynamic: false
    }
  ],
  displays: [
    {
      vendor: '',
      model: '',
      deviceName: '',
      main: false,
      builtin: false,
      connection: 'XWAYLAND0',
      sizeX: null,
      sizeY: null,
      pixelDepth: null,
      resolutionX: null,
      resolutionY: null,
      currentResX: 1920,
      currentResY: 1080,
      positionX: 0,
      positionY: 0,
      currentRefreshRate: 59
    },
    {
      vendor: '',
      model: '',
      main: false,
      builtin: false,
      connection: 'XWAYLAND1',
      sizeX: null,
      sizeY: null,
      pixelDepth: null,
      resolutionX: null,
      resolutionY: null,
      currentResX: 1920,
      currentResY: 1080,
      positionX: 0,
      positionY: 0,
      currentRefreshRate: 59
    }
  ]
}
```