### PR TITLE
typescript typings fix TimeData

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -7,8 +7,8 @@ export namespace Systeminformation {
   // 1. General
 
   interface TimeData {
-    current: string;
-    uptime: string;
+    current: number;
+    uptime: number;
     timezone: string;
     timezoneName: string;
   }


### PR DESCRIPTION
noticed that `current` & `uptime` are currently defined to return a `string` when in fact they return a `number`