### PR TITLE
The Debian trademark is owned by Software in the Public Interest, Inc.

### DIFF
--- a/docs/trademarks.html
+++ b/docs/trademarks.html
@@ -54,7 +54,7 @@
                   <li><strong>AMD</strong> is a trademark of Advanced Micro Devices Inc.</li>
                   <li><strong>Ryzen</strong> is a trademark of Advanced Micro Devices Inc.</li>
                   <li><strong>Raspberry Pi</strong> is a trademark of the Raspberry Pi Foundation</li>
-                  <li><strong>Debian</strong> is a trademark of the Debian Project</li>
+                  <li><strong>Debian</strong> is a trademark owned by Software in the Public Interest, Inc.</li>
                   <li><strong>FreeBSD</strong> is a registered trademark of The FreeBSD Foundation</li>
                   <li><strong>NetBSD</strong> is a registered trademark of The NetBSD Foundation</li>
                   <li><strong>Docker</strong> is a trademark of Docker, Inc.</li>


### PR DESCRIPTION
Refering to https://www.debian.org/trademark, Debian's trademark is owned by Software in the Public Interest, Inc. Please see the debian.org page for details. Would be great if the documentation would reflect that....

Thanks for providing systeminformation! 