### PR TITLE
fix: set NetworkInterfacesData speed nullable

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -500,7 +500,7 @@ export namespace Systeminformation {
     type: string;
     duplex: string;
     mtu: number;
-    speed: number;
+    speed: number | null;
     dhcp: boolean;
     dnsSuffix: string;
     ieee8021xAuth: string;


### PR DESCRIPTION
because:
```
            speed: isNaN(speed) ? null : speed,
```

at https://github.com/sebhildebrandt/systeminformation/blob/master/lib/network.js#L236