### PR TITLE
Fix typo preventing build

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1010,7 +1010,7 @@ export function audio(cb?: (data: Systeminformation.AudioData[]) => any): Promis
 export function bluetoothDevices(cb?: (data: Systeminformation.BluetoothDeviceData[]) => any): Promise<Systeminformation.BluetoothDeviceData[]>;
 
 export function getStaticData(cb?: (data: Systeminformation.StaticData) => any): Promise<Systeminformation.StaticData>;
-export function getDynamicData(srv?: string, iface?: string, cb?: (data: any) => any): Promise<ysteminformation.DynamicData>;
+export function getDynamicData(srv?: string, iface?: string, cb?: (data: any) => any): Promise<Systeminformation.DynamicData>;
 export function getAllData(srv?: string, iface?: string, cb?: (data: any) => any): Promise<Systeminformation.StaticData & Systeminformation.DynamicData>;
 export function get(valuesObject: any, cb?: (data: any) => any): Promise<any>;
 export function observe(valuesObject: any, interval: number, cb?: (data: any) => any): number;


### PR DESCRIPTION
Fixes a typo introduced in 7b339a5 (v5.15.0), which results in the following error when building my project with `tsc`:

```ts
node_modules/.pnpm/systeminformation@5.15.0/node_modules/systeminformation/lib/index.d.ts:1013:96 - error TS2833: Cannot find namespace 'ysteminformation'. Did you mean 'Systeminformation'?

1013 export function getDynamicData(srv?: string, iface?: string, cb?: (data: any) => any): Promise<ysteminformation.DynamicData>;
```