### PR TITLE
Fix missing cpu count in docker.js

### DIFF
--- a/lib/docker.js
+++ b/lib/docker.js
@@ -361,7 +361,12 @@ function docker_calcCPUPercent(cpu_stats, precpu_stats) {
 
     if (systemDelta > 0.0 && cpuDelta > 0.0) {
       // calculate the change for the cpu usage of the container in between readings
-      cpuPercent = (cpuDelta / systemDelta) * cpu_stats.cpu_usage.percpu_usage.length * 100.0;
+      if(precpu_stats.online_cpus) {
+        cpuPercent = (cpuDelta / systemDelta) * precpu_stats.online_cpus * 100.0;
+      }
+      else {
+        cpuPercent = (cpuDelta / systemDelta) * cpu_stats.cpu_usage.percpu_usage.length * 100.0;
+      }
     }
 
     return cpuPercent;


### PR DESCRIPTION
There were silent errors in `docker_calcCPUPercent()` when `cpu_stats.cpu_usage.percpu_usage` was undefined.
Recent versions of the Docker API now provide the `precpu_stats.online_cpus` property instead.
This PR adds support for the new cpu count property.