### PR TITLE
Change function signature networkInterfaces

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -977,7 +977,7 @@ export function networkInterfaceDefault(cb?: (data: string) => any): Promise<str
 export function networkGatewayDefault(cb?: (data: string) => any): Promise<string>;
 export function networkInterfaces(
   cb?:
-    | ((data: Systeminformation.NetworkInterfacesData[]) => any)
+    | ((data: Systeminformation.NetworkInterfacesData[] | Systeminformation.NetworkInterfacesData) => any)
     | boolean
     | string,
   rescan?: boolean,


### PR DESCRIPTION
Change function signature networkInterfaces as it also accepts rescan or defaultString as its first argument in the implemented code