### PR TITLE
feat: fix _psChild bug

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -400,7 +400,7 @@ function powerShellStart() {
         powerShellProceedResults(_psResult + _psError);
       });
       _psChild.on('close', function () {
-        _psChild.kill();
+        if(_psChild) _psChild.kill();
       });
     }
   }


### PR DESCRIPTION
hi：
when i open my electron app, i use si.powerShellStart() to create a new powerShell process，then i get some hardware infos, eg：cpu gpu display...I only need to get the above information once。So after 5 seconds I call  si.powerShellRelease(); But the windows pop-up window reported an error：kill is not defined，so i fix it

in lib/utils.js

line 403