### PR TITLE
graphics() added workAreaResulotionX, workAreaResulotionY, workAreaPositionX, workAreaPositionY (windows)

### DIFF
--- a/docs/graphics.html
+++ b/docs/graphics.html
@@ -549,6 +549,46 @@
                     </tr>
                     <tr>
                       <td></td>
+                      <td>...[0].workAreaResulotionX</td>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                      <td>X</td>
+                      <td></td>
+                      <td>working area resolution X</td>
+                    </tr>
+                    <tr>
+                      <td></td>
+                      <td>...[0].workAreaResulotionY</td>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                      <td>X</td>
+                      <td></td>
+                      <td>working area resolution Y</td>
+                    </tr>
+                    <tr>
+                      <td></td>
+                      <td>...[0].workAreaPositionX</td>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                      <td>X</td>
+                      <td></td>
+                      <td>working area position X</td>
+                    </tr>
+                    <tr>
+                      <td></td>
+                      <td>...[0].workAreaPositionY</td>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                      <td>X</td>
+                      <td></td>
+                      <td>working area position Y</td>
+                    </tr>
+                    <tr>
+                      <td></td>
                       <td>...[0].currentRefreshRate</td>
                       <td>X</td>
                       <td></td>
@@ -590,6 +630,10 @@ si.graphics().then(data => console.log(data));</code></pre class="example">
       currentResY: 1600,
       positionX: 0,
       positionY: 0,
+      workAreaResulotionX: 1600,
+      workAreaResulotionY: 2518,
+      workAreaPositionX: 0,
+      workAreaPositionY: 0,
       currentRefreshRate: null
     }
   ]

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -1048,6 +1048,7 @@ function graphics(callback) {
         const bitsPerPixel = util.getValue(linesScreen, 'BitsPerPixel');
         const bounds = util.getValue(linesScreen, 'Bounds').replace('{', '').replace('}', '').replace(/=/g, ':').split(',');
         const primary = util.getValue(linesScreen, 'Primary');
+        const workArea = util.getValue(linesScreen, 'WorkingArea').replace('{', '').replace('}', '').replace(/=/g, ':').split(',');
         const sizeX = util.getValue(linesMonitor, 'MaxHorizontalImageSize');
         const sizeY = util.getValue(linesMonitor, 'MaxVerticalImageSize');
         const instanceName = util.getValue(linesMonitor, 'InstanceName').toLowerCase();
@@ -1077,6 +1078,10 @@ function graphics(callback) {
           currentResY: util.toInt(util.getValue(bounds, 'Height', ':')),
           positionX: util.toInt(util.getValue(bounds, 'X', ':')),
           positionY: util.toInt(util.getValue(bounds, 'Y', ':')),
+          workAreaResulotionX: util.toInt(util.getValue(workArea, 'Width', ':')),
+          workAreaResulotionY: util.toInt(util.getValue(workArea, 'Height', ':')),
+          workAreaPositionX: util.toInt(util.getValue(workArea, 'X', ':')),
+          workAreaPositionY: util.toInt(util.getValue(workArea, 'Y', ':')),
         });
       }
     }


### PR DESCRIPTION
Working area information from system.windows.forms.screen was missing, It represents the available area position and dimensions over the screen. Most common reason to working area != current resolution is when windows task bar is docked on a certain screen. Use cases:

1. Application should rely on this one to fill only working area and not the entire screen and prevent covering task bar.
2. Chromium and Electron are also providing that information

Documentation was updated accordingly.