### PR TITLE
fix: util getValue isMatchProperty

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -126,7 +126,7 @@ function getValue(lines, property, separator, trimmed, lineMatch) {
     }
     if (lineLower.startsWith(property) && (lineMatch ? (lineLower.match(property + separator)) : true)) {
       const parts = trimmed ? line.trim().split(separator) : line.split(separator);
-      if (parts.length >= 2) {
+      if (parts.length >= 2 && trimmed ? parts[0].toLowerCase().replace(/\t/g, '').trim() === property : true) {
         parts.shift();
         result = parts.join(separator).trim();
       }

--- a/lib/util.js
+++ b/lib/util.js
@@ -126,7 +126,8 @@ function getValue(lines, property, separator, trimmed, lineMatch) {
     }
     if (lineLower.startsWith(property) && (lineMatch ? (lineLower.match(property + separator)) : true)) {
       const parts = trimmed ? line.trim().split(separator) : line.split(separator);
-      if (parts.length >= 2 && trimmed ? parts[0].toLowerCase().replace(/\t/g, '').trim() === property : true) {
+      const isMatchProperty = trimmed ? parts[0].toLowerCase().replace(/\t/g, '').trim() === property : parts[0].toLowerCase().replace(/\t/g, '') === property;
+      if (parts.length >= 2 && isMatchProperty) {
         parts.shift();
         result = parts.join(separator).trim();
       }


### PR DESCRIPTION
#773 

Describe the bug
Incorrect value fetched for mac m1 model.

To Reproduce
Steps to reproduce the behavior:

used function
si.get({system: "model,serial,uuid"})
Current Output

Get value is model-config value not model value.

Expected behavior
Get value should be model value

Environment (please complete the following information):

systeminformation package version:
OS: [macOS Big Sur]
Hardware [MacBook Pro (13-inch,M1,2020)]

this problem may be in lib/util.js, function getValue

![avatar](https://m.hellobike.com/resource/helloyun/15852/3nfbA_E9FD7448-D272-4048-A78E-A931DC3ACA20.png?x-oss-process=image/quality,q_80)

![avatar](https://m.hellobike.com/resource/helloyun/15852/WpTpj_5B85243E-0E4C-4E3E-B21A-72B6906B5663.png?x-oss-process=image/quality,q_80)
