### PR TITLE
getUniqueMacAdresses() os.networkInterfaces() Unknown system error 13 fix (Android 13)

### DIFF
--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -1047,25 +1047,29 @@ function shell(callback) {
 exports.shell = shell;
 
 function getUniqueMacAdresses() {
-  const ifaces = os.networkInterfaces();
   let macs = [];
-  for (let dev in ifaces) {
-    if ({}.hasOwnProperty.call(ifaces, dev)) {
-      ifaces[dev].forEach(function (details) {
-        if (details && details.mac && details.mac !== '00:00:00:00:00:00') {
-          const mac = details.mac.toLowerCase();
-          if (macs.indexOf(mac) === -1) {
-            macs.push(mac);
+  try {
+    const ifaces = os.networkInterfaces();
+    for (let dev in ifaces) {
+      if ({}.hasOwnProperty.call(ifaces, dev)) {
+        ifaces[dev].forEach(function (details) {
+          if (details && details.mac && details.mac !== '00:00:00:00:00:00') {
+            const mac = details.mac.toLowerCase();
+            if (macs.indexOf(mac) === -1) {
+              macs.push(mac);
+            }
           }
-        }
-      });
+        });
+      }
     }
+    macs = macs.sort(function (a, b) {
+      if (a < b) { return -1; }
+      if (a > b) { return 1; }
+      return 0;
+    });
+  } catch (e) {
+    macs.push('00:00:00:00:00:00');
   }
-  macs = macs.sort(function (a, b) {
-    if (a < b) { return -1; }
-    if (a > b) { return 1; }
-    return 0;
-  });
   return macs;
 }
 


### PR DESCRIPTION
Android 13 `os.networkInterfaces()` returned `Unknown system error 13`，use `try` to catch it
![Screenshot_2023-02-27-22-52-50-316_bin mt plus-ed](https://user-images.githubusercontent.com/63490117/221598891-35cd3a44-97ab-4eac-a3f1-570605cb82fc.jpg)
