### PR TITLE
Improve JSON parsing for usb devices on MacOS

### DIFF
--- a/lib/usb.js
+++ b/lib/usb.js
@@ -125,18 +125,34 @@ function parseDarwinUsb(usb, id) {
       if (lines[i] !== '{' && lines[i] !== '}' && lines[i + 1] && lines[i + 1].trim() !== '}') {
         lines[i] = lines[i] + ',';
       }
+
+      lines[i] = lines[i].replace(':Yes,', ':"Yes",');
       lines[i] = lines[i].replace(': Yes,', ': "Yes",');
+      lines[i] = lines[i].replace(': Yes', ': "Yes"');
+      lines[i] = lines[i].replace(':No,', ':"No",');
       lines[i] = lines[i].replace(': No,', ': "No",');
+      lines[i] = lines[i].replace(': No', ': "No"');
+
+      // In this case (("com.apple.developer.driverkit.transport.usb"))
+      lines[i] = lines[i].replace("((", "").replace("))", "")
+
+      // In case we have <923c11> we need make it "<923c11>" for correct JSON parse
+      let match = /<(\w+)>/.exec(lines[i]);
+
+      if (match) {
+        let number = match[0];
+        lines[i] = lines[i].replace(number, `"${number}"`);
+      } 
     }
     const usbObj = JSON.parse(lines.join('\n'));
-    const removableDrive = usbObj['Built-In'].toLowerCase() !== 'yes' && usbObj['non-removable'].toLowerCase() === 'no';
+    const removableDrive = usbObj['Built-In']?.toLowerCase() !== 'yes' && usbObj['non-removable']?.toLowerCase() === 'no';
 
     result.bus = null;
     result.deviceId = null;
     result.id = usbObj['USB Address'] || null;
     result.name = usbObj['kUSBProductString'] || usbObj['USB Product Name'] || null;
-    result.type = getDarwinUsbType((usbObj['kUSBProductString'] || usbObj['USB Product Name'] || '').toLowerCase() + (removableDrive ? ' removable' : ''));
-    result.removable = usbObj['non-removable'].toLowerCase() === 'no';
+    result.type = getDarwinUsbType((usbObj['kUSBProductString'] || usbObj['USB Product Name'] || '')?.toLowerCase() + (removableDrive ? ' removable' : ''));
+    result.removable = usbObj['non-removable']?.toLowerCase() === 'no';
     result.vendor = usbObj['kUSBVendorString'] || usbObj['USB Vendor Name'] || null;
     result.manufacturer = usbObj['kUSBVendorString'] || usbObj['USB Vendor Name'] || null;
     result.maxPower = null;

--- a/lib/usb.js
+++ b/lib/usb.js
@@ -151,7 +151,7 @@ function parseDarwinUsb(usb, id) {
     result.deviceId = null;
     result.id = usbObj['USB Address'] || null;
     result.name = usbObj['kUSBProductString'] || usbObj['USB Product Name'] || null;
-    result.type = getDarwinUsbType((usbObj['kUSBProductString'] || usbObj['USB Product Name'] || '')?.toLowerCase() + (removableDrive ? ' removable' : ''));
+    result.type = getDarwinUsbType((usbObj['kUSBProductString'] || usbObj['USB Product Name'] || '').toLowerCase() + (removableDrive ? ' removable' : ''));
     result.removable = usbObj['non-removable']?.toLowerCase() === 'no';
     result.vendor = usbObj['kUSBVendorString'] || usbObj['USB Vendor Name'] || null;
     result.manufacturer = usbObj['kUSBVendorString'] || usbObj['USB Vendor Name'] || null;


### PR DESCRIPTION
Hi, I am faced with incorrect parsing on my MacOs and found problem with JSON parsing, now it works well
<img width="286" alt="223781386-1f4a87c3-3508-4a53-a510-291a313f4e90" src="https://user-images.githubusercontent.com/48012812/223785077-5826b666-2916-471b-860d-9b704f67af54.png">


But it still doesn't show the device type, and unfortunately it doesn't seem like I can fix it.
<img width="370" alt="image" src="https://user-images.githubusercontent.com/48012812/223781592-9de09fa2-f6e8-4bfc-9c42-aa0cf5ba885d.png">

Because there is no information about it before parsing and this is not a problem in this MR (just for fact)
<img width="532" alt="image" src="https://user-images.githubusercontent.com/48012812/223783380-efad727d-48e6-43eb-a5f1-4ea0adc7c56c.png">


