### PR TITLE
fsSize() option to return only a specific drive on Windows

### DIFF
--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -36,7 +36,7 @@ let _disk_io = {};
 // --------------------------
 // FS - mounted file systems
 
-function fsSize(callback) {
+function fsSize(callback, drive) {
 
   let macOsDisks = [];
   let osMounts = [];
@@ -173,7 +173,8 @@ function fsSize(callback) {
       if (_windows) {
         try {
           // util.wmic('logicaldisk get Caption,FileSystem,FreeSpace,Size').then((stdout) => {
-          util.powerShell('Get-CimInstance Win32_logicaldisk | select Access,Caption,FileSystem,FreeSpace,Size | fl').then((stdout, error) => {
+          const cmd = `Get-WmiObject Win32_logicaldisk | select Caption,FileSystem,FreeSpace,Size ${drive ? `| where -property Caption -eq ` + drive : ''} | fl`;
+          util.powerShell(cmd).then((stdout, error) => {
             if (!error) {
               let devices = stdout.toString().split(/\n\s*\n/);
               devices.forEach(function (device) {

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -966,7 +966,7 @@ export function memLayout(cb?: (data: Systeminformation.MemLayoutData[]) => any)
 export function battery(cb?: (data: Systeminformation.BatteryData) => any): Promise<Systeminformation.BatteryData>;
 export function graphics(cb?: (data: Systeminformation.GraphicsData) => any): Promise<Systeminformation.GraphicsData>;
 
-export function fsSize(cb?: (data: Systeminformation.FsSizeData[]) => any): Promise<Systeminformation.FsSizeData[]>;
+export function fsSize(cb?: (data: Systeminformation.FsSizeData[]) => any, drive?: string): Promise<Systeminformation.FsSizeData[]>;
 export function fsOpenFiles(cb?: (data: Systeminformation.FsOpenFilesData[]) => any): Promise<Systeminformation.FsOpenFilesData[]>;
 export function blockDevices(cb?: (data: Systeminformation.BlockDevicesData[]) => any): Promise<Systeminformation.BlockDevicesData[]>;
 export function fsStats(cb?: (data: Systeminformation.FsStatsData) => any): Promise<Systeminformation.FsStatsData>;


### PR DESCRIPTION
Fixes #680

I tested it and I have the same result as comment in the issue.