### PR TITLE
Fixes Issue: #794 - The "services" is typed wrong in type "DynamicData"

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -931,7 +931,7 @@ export namespace Systeminformation {
     networkConnections: NetworkConnectionsData;
     mem: MemData;
     battery: BatteryData;
-    services: ServicesData;
+    services: ServicesData[];
     fsSize: FsSizeData;
     fsStats: FsStatsData;
     disksIO: DisksIoData;


### PR DESCRIPTION
Fixes Issue: #794 - The "services" is typed wrong in type "DynamicData"