### PR TITLE
osInfo() fixed issues with getting fqdn and hiding command not found

### DIFF
--- a/lib/osinfo.js
+++ b/lib/osinfo.js
@@ -165,18 +165,30 @@ function getLogoFile(distro) {
 // FQDN
 
 function getFQDN() {
-  let fqdn = os.hostname;
+  let fqdn = os.hostname();
+
+  const execSyncOpts = {
+    stdio: 'pipe'
+  };
+
   if (_linux || _darwin) {
     try {
-      const stdout = execSync('hostname -f');
-      fqdn = stdout.toString().split(os.EOL)[0];
+      const stdout = execSync('hostnamectl --json short', execSyncOpts);
+      const json = JSON.parse(stdout.toString());
+
+      fqdn = json['StaticHostname'];
     } catch (e) {
-      util.noop();
+      try {
+        const stdout = execSync('hostname -f', execSyncOpts);
+        fqdn = stdout.toString().split(os.EOL)[0];
+      } catch (e) {
+        util.noop();
+      }
     }
   }
   if (_freebsd || _openbsd || _netbsd) {
     try {
-      const stdout = execSync('hostname');
+      const stdout = execSync('hostname', execSyncOpts);
       fqdn = stdout.toString().split(os.EOL)[0];
     } catch (e) {
       util.noop();


### PR DESCRIPTION
fixes #796 

This PR will:
* Ensure a string is always returned from `getFQDN` if the FQDN cannot be gotten using commands.
* Hide any warnings from the console if a command is not found for retrieving the FQDN.
* Attempt to use `hostnamectl` before using `hostname -f` as it comes preinstalled on systemd based systems, and reports changes made to the `/etc/hostname` file (whereas `hostname -f` either does not or only does after rebooting the system).