### PR TITLE
Use NoProfile argument for PowerShell processes

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -377,7 +377,7 @@ function powerShellProceedResults(data) {
 
 function powerShellStart() {
   if (!_psChild) {
-    _psChild = spawn('powershell.exe', ['-NoLogo', '-InputFormat', 'Text', '-NoExit', '-Command', '-'], {
+    _psChild = spawn('powershell.exe', ['-NoProfile', '-NoLogo', '-InputFormat', 'Text', '-NoExit', '-Command', '-'], {
       stdio: 'pipe',
       windowsHide: true,
       maxBuffer: 1024 * 20000,
@@ -450,7 +450,7 @@ function powerShell(cmd) {
     return new Promise((resolve) => {
       process.nextTick(() => {
         try {
-          const child = spawn('powershell.exe', ['-NoLogo', '-InputFormat', 'Text', '-NoExit', '-ExecutionPolicy', 'Unrestricted', '-Command', '-'], {
+          const child = spawn('powershell.exe', ['-NoProfile', '-NoLogo', '-InputFormat', 'Text', '-NoExit', '-ExecutionPolicy', 'Unrestricted', '-Command', '-'], {
             stdio: 'pipe',
             windowsHide: true,
             maxBuffer: 1024 * 20000,


### PR DESCRIPTION
The `-NoProfile` parameter in PowerShell is used to prevent the loading of user profile scripts when starting the PowerShell environment.