### PR TITLE
Improve ultil.getValue()

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -119,7 +119,7 @@ function getValue(lines, property, separator, trimmed, lineMatch) {
   trimmed = trimmed || false;
   lineMatch = lineMatch || false;
   let result = '';
-  lines.forEach((line) => {
+  lines.some((line) => {
     let lineLower = line.toLowerCase().replace(/\t/g, '');
     if (trimmed) {
       lineLower = lineLower.trim();
@@ -129,6 +129,7 @@ function getValue(lines, property, separator, trimmed, lineMatch) {
       if (parts.length >= 2) {
         parts.shift();
         result = parts.join(separator).trim();
+        return true;
       }
     }
   });


### PR DESCRIPTION
getValue() now returns the first match case instead of the last one

**Describe the bug**
Incorrect value fetched for Mac m1 disksLayout

**To Reproduce**
Steps to reproduce the behavior:

**used function**
si.diskLayout()
Current Output
[ { **device: 'disk0s5',**
    type: 'NVMe',
    name: 'APPLE SSD AP1024R',
    vendor: 'Apple',
    size: 1000555581440,
...
}]


Expected behavior
[ { **device: 'disk0',**
    type: 'NVMe',
    name: 'APPLE SSD AP1024R',
    vendor: 'Apple',
    size: 1000555581440,
...
}]

Environment (please complete the following information):

systeminformation package version:
OS: [macOS 14.03]
Hardware [MacBook Pro (16-inch,M1,2021)]

this problem may be in lib/util.js, function getValue