### PR TITLE
Code name added for macOS 13 (Ventura) & 14 (Sonoma)

### DIFF
--- a/src/darwin/os-info.ts
+++ b/src/darwin/os-info.ts
@@ -30,6 +30,8 @@ export const darwinOsInfo = async () => {
       case result.release.indexOf('10.15') > -1: result.codename = 'macOS Catalina'; break;
       case result.release.startsWith('11.'): result.codename = 'macOS Big Sur'; break;
       case result.release.startsWith('12.'): result.codename = 'macOS Monterey'; break;
+      case result.release.startsWith('13.'): result.codename = "macOS Ventura"; break;
+      case result.release.startsWith('14.'): result.codename = "macOS Sonoma"; break;
       default: result.codename = 'macOS';
     }
     result.uefi = true;


### PR DESCRIPTION
This commit introduces the addition of code names for the versions of macOS, namely macOS 13 with the code name "Ventura" and macOS 14 with the code name "Sonoma"