### PR TITLE
Windows graphics changes

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -939,7 +939,7 @@ function graphics(callback) {
         productionYear: '',
         serial: '',
         displayId: tsection.InstanceName,
-        main: '',
+        main: false,
         builtin: ['2147483648', '4294967295'].includes(tsection.VideoOutputTechnology), //*
         connection: videoTypes[tsection.VideoOutputTechnology], //*
         sizeX: '',

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -52,7 +52,8 @@ const videoTypes = {
   '13': 'UDI embedded',
   '14': 'SDTVDONGLE',
   '15': 'MIRACAST',
-  '2147483648': 'INTERNAL'
+  '2147483648': 'INTERNAL',
+  '4294967295': 'RDP'
 };
 
 function getVendorFromModel(model) {
@@ -869,6 +870,7 @@ function graphics(callback) {
             const dsections = giveMeJson(data[2])
             const msections = giveMeJson(data[3])
             const tsections = giveMeJson(data[4])
+            console.log('tsections', tsections)
             // const ssections = giveMeJson(data[6]) I cannot find a reliable method to correlate this with the displays from the other output
             const isections = []
             data[5].split('\r\n').forEach((display) => {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -936,7 +936,7 @@ function graphics(callback) {
         vendor: '',
         deviceName: '',
         model: '',
-        productionYear: '',
+        productionYear: 0,
         serial: '',
         displayId: tsection.InstanceName,
         main: false,
@@ -969,7 +969,6 @@ function graphics(callback) {
         display.resolutionX = util.toInt(dsection.ScreenWidth)
         display.resolutionY = util.toInt(dsection.ScreenHeight)
         display.model = dsection.Name.split('(', 1)[0].trim()
-        display.productionYear = dsection.ManufactureYearWeek
         display.serial = dsection.SerialNumberID
       } else {
         display.resolutionX = 0;
@@ -983,7 +982,7 @@ function graphics(callback) {
         display.sizeY = 0
       }
       if (isection) {
-        display.productionYear = isection.YearOfManufacture
+        display.productionYear = util.toInt(isection.YearOfManufacture)
         if (display.vendor === '') {
           display.vendor = isection.ManufacturerName
         }

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -870,7 +870,6 @@ function graphics(callback) {
             const dsections = giveMeJson(data[2])
             const msections = giveMeJson(data[3])
             const tsections = giveMeJson(data[4])
-            console.log('tsections', tsections)
             // const ssections = giveMeJson(data[6]) I cannot find a reliable method to correlate this with the displays from the other output
             const isections = []
             data[5].split('\r\n').forEach((display) => {

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -18,7 +18,7 @@ const exec = require('child_process').exec;
 const execSync = require('child_process').execSync;
 const util = require('./util');
 
-let _platform = process.platform;
+const _platform = process.platform;
 let _nvidiaSmiPath = '';
 
 const _linux = (_platform === 'linux' || _platform === 'android');
@@ -52,7 +52,8 @@ const videoTypes = {
   '13': 'UDI embedded',
   '14': 'SDTVDONGLE',
   '15': 'MIRACAST',
-  '2147483648': 'INTERNAL'
+  '2147483648': 'INTERNAL',
+  '4294967295': 'RDP'
 };
 
 function getVendorFromModel(model) {
@@ -827,11 +828,11 @@ function graphics(callback) {
           const workload = [];
           workload.push(util.powerShell('Get-CimInstance win32_VideoController | fl *'));
           workload.push(util.powerShell('gp "HKLM:\\SYSTEM\\ControlSet001\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\*" -ErrorAction SilentlyContinue | where MatchingDeviceId $null -NE | select MatchingDeviceId,HardwareInformation.qwMemorySize | fl'));
-          workload.push(util.powerShell('Get-CimInstance win32_desktopmonitor | fl *'));
-          workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorBasicDisplayParams | fl'));
-          workload.push(util.powerShell('Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Screen]::AllScreens'));
+          workload.push(util.powerShell('Get-CimInstance win32_desktopmonitor | select * | fl *'));
+          workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorBasicDisplayParams | fl *'));
           workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorConnectionParams | fl'));
-          workload.push(util.powerShell('gwmi WmiMonitorID -Namespace root\\wmi | ForEach-Object {(($_.ManufacturerName -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.ProductCodeID -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.UserFriendlyName -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.SerialNumberID -notmatch 0 | foreach {[char]$_}) -join "") + "|" + $_.InstanceName}'));
+          workload.push(util.powerShell('gwmi WmiMonitorID -Namespace root\\wmi | ForEach-Object {("ManufacturerName:" +( $_.ManufacturerName -notmatch 0 | foreach {[char]$_}) -join "") + "|ProductCodeID:" + (($_.ProductCodeID -notmatch 0 | foreach {[char]$_}) -join "") + "|UserFriendlyName:" + (($_.UserFriendlyName -notmatch 0 | foreach {[char]$_}) -join "") + "|SerialNumberID:" + (($_.SerialNumberID -notmatch 0 | foreach {[char]$_}) -join "") + "|InstanceName:" + $_.InstanceName + "|YearOfManufacture:" + $_.YearOfManufacture}'))
+          workload.push(util.powerShell('Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Screen]::AllScreens'));
 
           const nvidiaData = nvidiaDevices();
 
@@ -839,8 +840,8 @@ function graphics(callback) {
             workload
           ).then((data) => {
             // controller + vram
-            let csections = data[0].replace(/\r/g, '').split(/\n\s*\n/);
-            let vsections = data[1].replace(/\r/g, '').split(/\n\s*\n/);
+            const csections = data[0].replace(/\r/g, '').split(/\n\s*\n/);
+            const vsections = data[1].replace(/\r/g, '').split(/\n\s*\n/);
             result.controllers = parseLinesWindowsControllers(csections, vsections);
             result.controllers = result.controllers.map((controller) => { // match by subDeviceId
               if (controller.vendor.toLowerCase() === 'nvidia') {
@@ -866,65 +867,23 @@ function graphics(callback) {
             });
 
             // displays
-            let dsections = data[2].replace(/\r/g, '').split(/\n\s*\n/);
-            // result.displays = parseLinesWindowsDisplays(dsections);
-            if (dsections[0].trim() === '') { dsections.shift(); }
-            if (dsections.length && dsections[dsections.length - 1].trim() === '') { dsections.pop(); }
-
-            // monitor (powershell)
-            let msections = data[3].replace(/\r/g, '').split('Active ');
-            msections.shift();
-
-            // forms.screens (powershell)
-            let ssections = data[4].replace(/\r/g, '').split('BitsPerPixel ');
-            ssections.shift();
-
-            // connection params (powershell) - video type
-            let tsections = data[5].replace(/\r/g, '').split(/\n\s*\n/);
-            tsections.shift();
-
-            // monitor ID (powershell) - model / vendor
-            const res = data[6].replace(/\r/g, '').split(/\n/);
-            let isections = [];
-            res.forEach(element => {
-              const parts = element.split('|');
-              if (parts.length === 5) {
-                isections.push({
-                  vendor: parts[0],
-                  code: parts[1],
-                  model: parts[2],
-                  serial: parts[3],
-                  instanceId: parts[4]
-                });
-              }
-            });
-
-            result.displays = parseLinesWindowsDisplaysPowershell(ssections, msections, dsections, tsections, isections);
-
-            if (result.displays.length === 1) {
-              if (_resolutionX) {
-                result.displays[0].resolutionX = _resolutionX;
-                if (!result.displays[0].currentResX) {
-                  result.displays[0].currentResX = _resolutionX;
+            const dsections = giveMeJson(data[2])
+            const msections = giveMeJson(data[3])
+            const tsections = giveMeJson(data[4])
+            // const ssections = giveMeJson(data[6]) I cannot find a reliable method to correlate this with the displays from the other output
+            const isections = []
+            data[5].split('\r\n').forEach((display) => {
+              const newDisplay = {}
+              display.split('|').forEach((chunk) => {
+                const entries = chunk.split(':')
+                  if (entries.length === 2) {
+                    newDisplay[entries[0].trim()] = entries[1].trim()
+                  }
                 }
-              }
-              if (_resolutionY) {
-                result.displays[0].resolutionY = _resolutionY;
-                if (result.displays[0].currentResY === 0) {
-                  result.displays[0].currentResY = _resolutionY;
-                }
-              }
-              if (_pixelDepth) {
-                result.displays[0].pixelDepth = _pixelDepth;
-              }
-            }
-            result.displays = result.displays.map(element => {
-              if (_refreshRate && !element.currentRefreshRate) {
-                element.currentRefreshRate = _refreshRate;
-              }
-              return element;
-            });
-
+              )
+              isections.push(newDisplay)
+            })
+            result.displays = parseWindowsDisplays(dsections, msections, tsections, isections)
             if (callback) {
               callback(result);
             }
@@ -943,6 +902,105 @@ function graphics(callback) {
       }
     });
   });
+
+  function giveMeJson(windowsOutput) {
+    const newResult = []
+    windowsOutput.trim()
+      .replace(/\r/g, '')
+      .split(/\n\s*\n/)
+      .map((display, i) => {
+        const array = display.split('\n')
+        array.map(line => {
+          const entries = line.split(':')
+          if (entries.length === 2) {
+            if (!newResult[i]) {
+              newResult[i] = {};
+            }
+            newResult[i][entries[0].trim()] = entries[1].trim()
+            return entries
+          }
+        })
+      })
+    return newResult;
+  }
+
+
+  function parseWindowsDisplays(dsections, msections, tsections, isections) {
+    /**
+     * To tie everything together tsections.InstanceName is what is being used as the key.
+     * TSections is the object that will list every monitor when a RDP connection is being used.
+     */
+    const displays = []
+    tsections.forEach((tsection) => {
+      const display = {
+        vendor: '',
+        deviceName: '',
+        model: '',
+        productionYear: '',
+        serial: '',
+        displayId: tsection.InstanceName,
+        main: '',
+        builtin: ['2147483648', '4294967295'].includes(tsection.VideoOutputTechnology), //*
+        connection: videoTypes[tsection.VideoOutputTechnology], //*
+        sizeX: '',
+        sizeY: '',
+        pixelDepth: 0,
+        resolutionX: '',
+        resolutionY: '',
+        currentResX: '',
+        currentResY: '',
+        positionX: '',
+        positionY: '',
+        currentRefreshRate: 0,
+      }
+      const dsection = dsections.find((dsection) => {
+        return `${dsection.PNPDeviceID}_0` === tsection.InstanceName.toUpperCase()
+      })
+      const msection = msections.find((msection) => {
+        return msection.InstanceName === tsection.InstanceName
+      })
+      const isection = isections.find((isection) => {
+        return `${isection.InstanceName}` === tsection.InstanceName
+      })
+      if (dsection) {
+        display.vendor = dsection.MonitorManufacturer
+        display.deviceName = dsection.Name
+        display.displayId = tsection.InstanceName
+        display.resolutionX = util.toInt(dsection.ScreenWidth)
+        display.resolutionY = util.toInt(dsection.ScreenHeight)
+        display.model = dsection.Name.split('(', 1)[0].trim()
+        display.productionYear = dsection.ManufactureYearWeek
+        display.serial = dsection.SerialNumberID
+      } else {
+        display.resolutionX = 0;
+        display.resolutionY = 0;
+      }
+      if (msection) {
+        display.sizeX = util.toInt(msection.MaxHorizontalImageSize);
+        display.sizeY = util.toInt(msection.MaxVerticalImageSize);
+      } else {
+        display.sizeX = 0
+        display.sizeY = 0
+      }
+      if (isection) {
+        display.productionYear = isection.YearOfManufacture
+        if (display.vendor === '') {
+          display.vendor = isection.ManufacturerName
+        }
+        display.serial = isection.SerialNumberID
+        if (display.deviceName === '') {
+          display.deviceName = isection.UserFriendlyName
+          display.model = isection.UserFriendlyName
+        }
+      }
+      display.positionX = 0;
+      display.positionY = 0;
+      display.currentResX = display.resolutionX;
+      display.currentResY = display.resolutionY;
+      displays.push(display)
+    })
+    return displays
+  }
 
   function parseLinesWindowsControllers(sections, vections) {
     const memorySizes = {};
@@ -968,12 +1026,12 @@ function graphics(callback) {
       }
     }
 
-    let controllers = [];
-    for (let i in sections) {
+    const controllers = [];
+    for (const i in sections) {
       if ({}.hasOwnProperty.call(sections, i)) {
         if (sections[i].trim() !== '') {
-          let lines = sections[i].trim().split('\n');
-          let pnpDeviceId = util.getValue(lines, 'PNPDeviceID', ':').match(/PCI\\(VEN_[0-9A-F]{4})&(DEV_[0-9A-F]{4})(?:&(SUBSYS_[0-9A-F]{8}))?(?:&(REV_[0-9A-F]{2}))?/i);
+          const lines = sections[i].trim().split('\n');
+          const pnpDeviceId = util.getValue(lines, 'PNPDeviceID', ':').match(/PCI\\(VEN_[0-9A-F]{4})&(DEV_[0-9A-F]{4})(?:&(SUBSYS_[0-9A-F]{8}))?(?:&(REV_[0-9A-F]{2}))?/i);
           let subDeviceId = null;
           let memorySize = null;
           if (pnpDeviceId) {
@@ -1034,88 +1092,6 @@ function graphics(callback) {
       }
     }
     return controllers;
-  }
-
-  function parseLinesWindowsDisplaysPowershell(ssections, msections, dsections, tsections, isections) {
-    let displays = [];
-    let vendor = '';
-    let model = '';
-    let deviceID = '';
-    let resolutionX = 0;
-    let resolutionY = 0;
-    if (dsections && dsections.length) {
-      let linesDisplay = dsections[0].split('\n');
-      vendor = util.getValue(linesDisplay, 'MonitorManufacturer', ':');
-      model = util.getValue(linesDisplay, 'Name', ':');
-      deviceID = util.getValue(linesDisplay, 'PNPDeviceID', ':').replace(/&amp;/g, '&').toLowerCase();
-      resolutionX = util.toInt(util.getValue(linesDisplay, 'ScreenWidth', ':'));
-      resolutionY = util.toInt(util.getValue(linesDisplay, 'ScreenHeight', ':'));
-    }
-    for (let i = 0; i < ssections.length; i++) {
-      if (ssections[i].trim() !== '') {
-        ssections[i] = 'BitsPerPixel ' + ssections[i];
-        msections[i] = 'Active ' + msections[i];
-        // tsections can be empty OR undefined on earlier versions of powershell (<=2.0)
-        // Tag connection type as UNKNOWN by default if this information is missing
-        if (tsections.length === 0 || tsections[i] === undefined) {
-          tsections[i] = 'Unknown';
-        }
-        let linesScreen = ssections[i].split('\n');
-        let linesMonitor = msections[i].split('\n');
-
-        let linesConnection = tsections[i].split('\n');
-        const bitsPerPixel = util.getValue(linesScreen, 'BitsPerPixel');
-        const bounds = util.getValue(linesScreen, 'Bounds').replace('{', '').replace('}', '').replace(/=/g, ':').split(',');
-        const primary = util.getValue(linesScreen, 'Primary');
-        const sizeX = util.getValue(linesMonitor, 'MaxHorizontalImageSize');
-        const sizeY = util.getValue(linesMonitor, 'MaxVerticalImageSize');
-        const instanceName = util.getValue(linesMonitor, 'InstanceName').toLowerCase();
-        const videoOutputTechnology = util.getValue(linesConnection, 'VideoOutputTechnology');
-        const deviceName = util.getValue(linesScreen, 'DeviceName');
-        let displayVendor = '';
-        let displayModel = '';
-        isections.forEach(element => {
-          if (element.instanceId.toLowerCase().startsWith(instanceName) && vendor.startsWith('(') && model.startsWith('PnP')) {
-            displayVendor = element.vendor;
-            displayModel = element.model;
-          }
-        });
-        displays.push({
-          vendor: instanceName.startsWith(deviceID) && displayVendor === '' ? vendor : displayVendor,
-          model: instanceName.startsWith(deviceID) && displayModel === '' ? model : displayModel,
-          deviceName,
-          main: primary.toLowerCase() === 'true',
-          builtin: videoOutputTechnology === '2147483648',
-          connection: videoOutputTechnology && videoTypes[videoOutputTechnology] ? videoTypes[videoOutputTechnology] : '',
-          resolutionX: util.toInt(util.getValue(bounds, 'Width', ':')),
-          resolutionY: util.toInt(util.getValue(bounds, 'Height', ':')),
-          sizeX: sizeX ? parseInt(sizeX, 10) : null,
-          sizeY: sizeY ? parseInt(sizeY, 10) : null,
-          pixelDepth: bitsPerPixel,
-          currentResX: util.toInt(util.getValue(bounds, 'Width', ':')),
-          currentResY: util.toInt(util.getValue(bounds, 'Height', ':')),
-          positionX: util.toInt(util.getValue(bounds, 'X', ':')),
-          positionY: util.toInt(util.getValue(bounds, 'Y', ':')),
-        });
-      }
-    }
-    if (ssections.length === 0) {
-      displays.push({
-        vendor,
-        model,
-        main: true,
-        sizeX: null,
-        sizeY: null,
-        resolutionX,
-        resolutionY,
-        pixelDepth: null,
-        currentResX: resolutionX,
-        currentResY: resolutionY,
-        positionX: 0,
-        positionY: 0
-      });
-    }
-    return displays;
   }
 }
 

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -936,21 +936,21 @@ function graphics(callback) {
         vendor: '',
         deviceName: '',
         model: '',
-        productionYear: 0,
         serial: '',
         displayId: tsection.InstanceName,
         main: false,
-        builtin: ['2147483648', '4294967295'].includes(tsection.VideoOutputTechnology), //*
-        connection: videoTypes[tsection.VideoOutputTechnology], //*
-        sizeX: '',
-        sizeY: '',
+        builtin: ['2147483648', '4294967295'].includes(tsection.VideoOutputTechnology),
+        connection: videoTypes[tsection.VideoOutputTechnology] ? videoTypes[tsection.VideoOutputTechnology] : 'Unknown',
+        productionYear: 0,
+        sizeX: 0,
+        sizeY: 0,
         pixelDepth: 0,
-        resolutionX: '',
-        resolutionY: '',
-        currentResX: '',
-        currentResY: '',
-        positionX: '',
-        positionY: '',
+        resolutionX: 0,
+        resolutionY: 0,
+        currentResX: 0,
+        currentResY: 0,
+        positionX: 0,
+        positionY: 0,
         currentRefreshRate: 0,
       }
       const dsection = dsections.find((dsection) => {
@@ -970,16 +970,10 @@ function graphics(callback) {
         display.resolutionY = util.toInt(dsection.ScreenHeight)
         display.model = dsection.Name.split('(', 1)[0].trim()
         display.serial = dsection.SerialNumberID
-      } else {
-        display.resolutionX = 0;
-        display.resolutionY = 0;
       }
       if (msection) {
         display.sizeX = util.toInt(msection.MaxHorizontalImageSize);
         display.sizeY = util.toInt(msection.MaxVerticalImageSize);
-      } else {
-        display.sizeX = 0
-        display.sizeY = 0
       }
       if (isection) {
         display.productionYear = util.toInt(isection.YearOfManufacture)
@@ -992,8 +986,6 @@ function graphics(callback) {
           display.model = isection.UserFriendlyName
         }
       }
-      display.positionX = 0;
-      display.positionY = 0;
       display.currentResX = display.resolutionX;
       display.currentResY = display.resolutionY;
       displays.push(display)

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -18,7 +18,7 @@ const exec = require('child_process').exec;
 const execSync = require('child_process').execSync;
 const util = require('./util');
 
-let _platform = process.platform;
+const _platform = process.platform;
 let _nvidiaSmiPath = '';
 
 const _linux = (_platform === 'linux' || _platform === 'android');
@@ -827,11 +827,11 @@ function graphics(callback) {
           const workload = [];
           workload.push(util.powerShell('Get-CimInstance win32_VideoController | fl *'));
           workload.push(util.powerShell('gp "HKLM:\\SYSTEM\\ControlSet001\\Control\\Class\\{4d36e968-e325-11ce-bfc1-08002be10318}\\*" -ErrorAction SilentlyContinue | where MatchingDeviceId $null -NE | select MatchingDeviceId,HardwareInformation.qwMemorySize | fl'));
-          workload.push(util.powerShell('Get-CimInstance win32_desktopmonitor | fl *'));
-          workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorBasicDisplayParams | fl'));
-          workload.push(util.powerShell('Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Screen]::AllScreens'));
+          workload.push(util.powerShell('Get-CimInstance win32_desktopmonitor | select * | fl *'));
+          workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorBasicDisplayParams | fl *'));
           workload.push(util.powerShell('Get-CimInstance -Namespace root\\wmi -ClassName WmiMonitorConnectionParams | fl'));
-          workload.push(util.powerShell('gwmi WmiMonitorID -Namespace root\\wmi | ForEach-Object {(($_.ManufacturerName -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.ProductCodeID -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.UserFriendlyName -notmatch 0 | foreach {[char]$_}) -join "") + "|" + (($_.SerialNumberID -notmatch 0 | foreach {[char]$_}) -join "") + "|" + $_.InstanceName}'));
+          workload.push(util.powerShell('gwmi WmiMonitorID -Namespace root\\wmi | ForEach-Object {("ManufacturerName:" +( $_.ManufacturerName -notmatch 0 | foreach {[char]$_}) -join "") + "|ProductCodeID:" + (($_.ProductCodeID -notmatch 0 | foreach {[char]$_}) -join "") + "|UserFriendlyName:" + (($_.UserFriendlyName -notmatch 0 | foreach {[char]$_}) -join "") + "|SerialNumberID:" + (($_.SerialNumberID -notmatch 0 | foreach {[char]$_}) -join "") + "|InstanceName:" + $_.InstanceName + "|YearOfManufacture:" + $_.YearOfManufacture}'))
+          workload.push(util.powerShell('Add-Type -AssemblyName System.Windows.Forms; [System.Windows.Forms.Screen]::AllScreens'));
 
           const nvidiaData = nvidiaDevices();
 
@@ -839,8 +839,8 @@ function graphics(callback) {
             workload
           ).then((data) => {
             // controller + vram
-            let csections = data[0].replace(/\r/g, '').split(/\n\s*\n/);
-            let vsections = data[1].replace(/\r/g, '').split(/\n\s*\n/);
+            const csections = data[0].replace(/\r/g, '').split(/\n\s*\n/);
+            const vsections = data[1].replace(/\r/g, '').split(/\n\s*\n/);
             result.controllers = parseLinesWindowsControllers(csections, vsections);
             result.controllers = result.controllers.map((controller) => { // match by subDeviceId
               if (controller.vendor.toLowerCase() === 'nvidia') {
@@ -866,65 +866,23 @@ function graphics(callback) {
             });
 
             // displays
-            let dsections = data[2].replace(/\r/g, '').split(/\n\s*\n/);
-            // result.displays = parseLinesWindowsDisplays(dsections);
-            if (dsections[0].trim() === '') { dsections.shift(); }
-            if (dsections.length && dsections[dsections.length - 1].trim() === '') { dsections.pop(); }
-
-            // monitor (powershell)
-            let msections = data[3].replace(/\r/g, '').split('Active ');
-            msections.shift();
-
-            // forms.screens (powershell)
-            let ssections = data[4].replace(/\r/g, '').split('BitsPerPixel ');
-            ssections.shift();
-
-            // connection params (powershell) - video type
-            let tsections = data[5].replace(/\r/g, '').split(/\n\s*\n/);
-            tsections.shift();
-
-            // monitor ID (powershell) - model / vendor
-            const res = data[6].replace(/\r/g, '').split(/\n/);
-            let isections = [];
-            res.forEach(element => {
-              const parts = element.split('|');
-              if (parts.length === 5) {
-                isections.push({
-                  vendor: parts[0],
-                  code: parts[1],
-                  model: parts[2],
-                  serial: parts[3],
-                  instanceId: parts[4]
-                });
-              }
-            });
-
-            result.displays = parseLinesWindowsDisplaysPowershell(ssections, msections, dsections, tsections, isections);
-
-            if (result.displays.length === 1) {
-              if (_resolutionX) {
-                result.displays[0].resolutionX = _resolutionX;
-                if (!result.displays[0].currentResX) {
-                  result.displays[0].currentResX = _resolutionX;
+            const dsections = giveMeJson(data[2])
+            const msections = giveMeJson(data[3])
+            const tsections = giveMeJson(data[4])
+            // const ssections = giveMeJson(data[6]) I cannot find a reliable method to correlate this with the displays from the other output
+            const isections = []
+            data[5].split('\r\n').forEach((display) => {
+              const newDisplay = {}
+              display.split('|').forEach((chunk) => {
+                const entries = chunk.split(':')
+                  if (entries.length === 2) {
+                    newDisplay[entries[0].trim()] = entries[1].trim()
+                  }
                 }
-              }
-              if (_resolutionY) {
-                result.displays[0].resolutionY = _resolutionY;
-                if (result.displays[0].currentResY === 0) {
-                  result.displays[0].currentResY = _resolutionY;
-                }
-              }
-              if (_pixelDepth) {
-                result.displays[0].pixelDepth = _pixelDepth;
-              }
-            }
-            result.displays = result.displays.map(element => {
-              if (_refreshRate && !element.currentRefreshRate) {
-                element.currentRefreshRate = _refreshRate;
-              }
-              return element;
-            });
-
+              )
+              isections.push(newDisplay)
+            })
+            result.displays = parseWindowsDisplays(dsections, msections, tsections, isections)
             if (callback) {
               callback(result);
             }
@@ -943,6 +901,105 @@ function graphics(callback) {
       }
     });
   });
+
+  function giveMeJson(windowsOutput) {
+    const newResult = []
+    windowsOutput.trim()
+      .replace(/\r/g, '')
+      .split(/\n\s*\n/)
+      .map((display, i) => {
+        const array = display.split('\n')
+        array.map(line => {
+          const entries = line.split(':')
+          if (entries.length === 2) {
+            if (!newResult[i]) {
+              newResult[i] = {};
+            }
+            newResult[i][entries[0].trim()] = entries[1].trim()
+            return entries
+          }
+        })
+      })
+    return newResult;
+  }
+
+
+  function parseWindowsDisplays(dsections, msections, tsections, isections) {
+    /**
+     * To tie everything together tsections.InstanceName is what is being used as the key.
+     * TSections is the object that will list every monitor when a RDP connection is being used.
+     */
+    const displays = []
+    tsections.forEach((tsection) => {
+      const display = {
+        vendor: '',
+        deviceName: '',
+        model: '',
+        productionYear: '',
+        serial: '',
+        displayId: tsection.InstanceName,
+        main: '',
+        builtin: ['2147483648', '4294967295'].includes(tsection.VideoOutputTechnology), //*
+        connection: videoTypes[tsection.VideoOutputTechnology], //*
+        sizeX: '',
+        sizeY: '',
+        pixelDepth: 0,
+        resolutionX: '',
+        resolutionY: '',
+        currentResX: '',
+        currentResY: '',
+        positionX: '',
+        positionY: '',
+        currentRefreshRate: 0,
+      }
+      const dsection = dsections.find((dsection) => {
+        return `${dsection.PNPDeviceID}_0` === tsection.InstanceName.toUpperCase()
+      })
+      const msection = msections.find((msection) => {
+        return msection.InstanceName === tsection.InstanceName
+      })
+      const isection = isections.find((isection) => {
+        return `${isection.InstanceName}` === tsection.InstanceName
+      })
+      if (dsection) {
+        display.vendor = dsection.MonitorManufacturer
+        display.deviceName = dsection.Name
+        display.displayId = tsection.InstanceName
+        display.resolutionX = util.toInt(dsection.ScreenWidth)
+        display.resolutionY = util.toInt(dsection.ScreenHeight)
+        display.model = dsection.Name.split('(', 1)[0].trim()
+        display.productionYear = dsection.ManufactureYearWeek
+        display.serial = dsection.SerialNumberID
+      } else {
+        display.resolutionX = 0;
+        display.resolutionY = 0;
+      }
+      if (msection) {
+        display.sizeX = util.toInt(msection.MaxHorizontalImageSize);
+        display.sizeY = util.toInt(msection.MaxVerticalImageSize);
+      } else {
+        display.sizeX = 0
+        display.sizeY = 0
+      }
+      if (isection) {
+        display.productionYear = isection.YearOfManufacture
+        if (display.vendor === '') {
+          display.vendor = isection.ManufacturerName
+        }
+        display.serial = isection.SerialNumberID
+        if (display.deviceName === '') {
+          display.deviceName = isection.UserFriendlyName
+          display.model = isection.UserFriendlyName
+        }
+      }
+      display.positionX = 0;
+      display.positionY = 0;
+      display.currentResX = display.resolutionX;
+      display.currentResY = display.resolutionY;
+      displays.push(display)
+    })
+    return displays
+  }
 
   function parseLinesWindowsControllers(sections, vections) {
     const memorySizes = {};
@@ -968,12 +1025,12 @@ function graphics(callback) {
       }
     }
 
-    let controllers = [];
-    for (let i in sections) {
+    const controllers = [];
+    for (const i in sections) {
       if ({}.hasOwnProperty.call(sections, i)) {
         if (sections[i].trim() !== '') {
-          let lines = sections[i].trim().split('\n');
-          let pnpDeviceId = util.getValue(lines, 'PNPDeviceID', ':').match(/PCI\\(VEN_[0-9A-F]{4})&(DEV_[0-9A-F]{4})(?:&(SUBSYS_[0-9A-F]{8}))?(?:&(REV_[0-9A-F]{2}))?/i);
+          const lines = sections[i].trim().split('\n');
+          const pnpDeviceId = util.getValue(lines, 'PNPDeviceID', ':').match(/PCI\\(VEN_[0-9A-F]{4})&(DEV_[0-9A-F]{4})(?:&(SUBSYS_[0-9A-F]{8}))?(?:&(REV_[0-9A-F]{2}))?/i);
           let subDeviceId = null;
           let memorySize = null;
           if (pnpDeviceId) {
@@ -1034,88 +1091,6 @@ function graphics(callback) {
       }
     }
     return controllers;
-  }
-
-  function parseLinesWindowsDisplaysPowershell(ssections, msections, dsections, tsections, isections) {
-    let displays = [];
-    let vendor = '';
-    let model = '';
-    let deviceID = '';
-    let resolutionX = 0;
-    let resolutionY = 0;
-    if (dsections && dsections.length) {
-      let linesDisplay = dsections[0].split('\n');
-      vendor = util.getValue(linesDisplay, 'MonitorManufacturer', ':');
-      model = util.getValue(linesDisplay, 'Name', ':');
-      deviceID = util.getValue(linesDisplay, 'PNPDeviceID', ':').replace(/&amp;/g, '&').toLowerCase();
-      resolutionX = util.toInt(util.getValue(linesDisplay, 'ScreenWidth', ':'));
-      resolutionY = util.toInt(util.getValue(linesDisplay, 'ScreenHeight', ':'));
-    }
-    for (let i = 0; i < ssections.length; i++) {
-      if (ssections[i].trim() !== '') {
-        ssections[i] = 'BitsPerPixel ' + ssections[i];
-        msections[i] = 'Active ' + msections[i];
-        // tsections can be empty OR undefined on earlier versions of powershell (<=2.0)
-        // Tag connection type as UNKNOWN by default if this information is missing
-        if (tsections.length === 0 || tsections[i] === undefined) {
-          tsections[i] = 'Unknown';
-        }
-        let linesScreen = ssections[i].split('\n');
-        let linesMonitor = msections[i].split('\n');
-
-        let linesConnection = tsections[i].split('\n');
-        const bitsPerPixel = util.getValue(linesScreen, 'BitsPerPixel');
-        const bounds = util.getValue(linesScreen, 'Bounds').replace('{', '').replace('}', '').replace(/=/g, ':').split(',');
-        const primary = util.getValue(linesScreen, 'Primary');
-        const sizeX = util.getValue(linesMonitor, 'MaxHorizontalImageSize');
-        const sizeY = util.getValue(linesMonitor, 'MaxVerticalImageSize');
-        const instanceName = util.getValue(linesMonitor, 'InstanceName').toLowerCase();
-        const videoOutputTechnology = util.getValue(linesConnection, 'VideoOutputTechnology');
-        const deviceName = util.getValue(linesScreen, 'DeviceName');
-        let displayVendor = '';
-        let displayModel = '';
-        isections.forEach(element => {
-          if (element.instanceId.toLowerCase().startsWith(instanceName) && vendor.startsWith('(') && model.startsWith('PnP')) {
-            displayVendor = element.vendor;
-            displayModel = element.model;
-          }
-        });
-        displays.push({
-          vendor: instanceName.startsWith(deviceID) && displayVendor === '' ? vendor : displayVendor,
-          model: instanceName.startsWith(deviceID) && displayModel === '' ? model : displayModel,
-          deviceName,
-          main: primary.toLowerCase() === 'true',
-          builtin: videoOutputTechnology === '2147483648',
-          connection: videoOutputTechnology && videoTypes[videoOutputTechnology] ? videoTypes[videoOutputTechnology] : '',
-          resolutionX: util.toInt(util.getValue(bounds, 'Width', ':')),
-          resolutionY: util.toInt(util.getValue(bounds, 'Height', ':')),
-          sizeX: sizeX ? parseInt(sizeX, 10) : null,
-          sizeY: sizeY ? parseInt(sizeY, 10) : null,
-          pixelDepth: bitsPerPixel,
-          currentResX: util.toInt(util.getValue(bounds, 'Width', ':')),
-          currentResY: util.toInt(util.getValue(bounds, 'Height', ':')),
-          positionX: util.toInt(util.getValue(bounds, 'X', ':')),
-          positionY: util.toInt(util.getValue(bounds, 'Y', ':')),
-        });
-      }
-    }
-    if (ssections.length === 0) {
-      displays.push({
-        vendor,
-        model,
-        main: true,
-        sizeX: null,
-        sizeY: null,
-        resolutionX,
-        resolutionY,
-        pixelDepth: null,
-        currentResX: resolutionX,
-        currentResY: resolutionY,
-        positionX: 0,
-        positionY: 0
-      });
-    }
-    return displays;
   }
 }
 

--- a/lib/network.js
+++ b/lib/network.js
@@ -359,6 +359,11 @@ function getWindowsIEEE8021x(connectionType, iface, ifaces) {
     state: 'Unknown',
     protocol: 'Unknown',
   };
+  
+  // Temp fix for vulnerability https://github.com/advisories/GHSA-cvv5-9h9w-qp2m
+  i8021x.state = 'Disabled';
+  i8021x.protocol = 'Not defined';
+  return i8021x;
 
   if (ifaces === 'Disabled') {
     i8021x.state = 'Disabled';

--- a/lib/system.js
+++ b/lib/system.js
@@ -320,7 +320,7 @@ exports.system = system;
 function cleanDefaults(s) {
   if (s === 'Default string') { s = ''; }
   if (s.toLowerCase().indexOf('o.e.m.') !== -1) { s = ''; }
-  
+
   return s
 }
 function bios(callback) {
@@ -561,8 +561,10 @@ function baseboard(callback) {
           const workload = [];
           const win10plus = parseInt(os.release()) >= 10;
           const maxCapacityAttribute = win10plus ? 'MaxCapacityEx' : 'MaxCapacity';
-          workload.push(util.powerShell('Get-CimInstance Win32_baseboard | select Model,Manufacturer,Product,Version,SerialNumber,PartNumber,SKU,SMBIOSAssetTag | fl'));
+          workload.push(util.powerShell('Get-CimInstance Win32_baseboard | select Model,Manufacturer,Product,Version,SerialNumber,PartNumber,SKU | fl'));
           workload.push(util.powerShell(`Get-CimInstance Win32_physicalmemoryarray | select ${maxCapacityAttribute}, MemoryDevices | fl`));
+          workload.push(util.powerShell('Get-CimInstance Win32_SystemEnclosure | select SMBIOSAssetTag | fl'));
+
           util.promiseAll(
             workload
           ).then((data) => {

--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -366,8 +366,11 @@ function parseWifiDarwin(wifiObj) {
           });
         }
       }
-      if (wifiItem.SSID) {
-        ssid = Buffer.from(wifiItem.SSID, 'base64').toString('utf8');
+      if (wifiItem.SSID && ssid === '') {
+        try {
+          console.log('Here')
+          ssid = Buffer.from(wifiItem.SSID, 'base64').toString('utf8');
+        } catch { }
       }
       result.push({
         ssid,

--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -466,21 +466,29 @@ function wifiNetworks(callback) {
         util.powerShell(cmd).then((stdout) => {
           const ssidParts = stdout.toString('utf8').split(os.EOL + os.EOL + 'SSID ');
           ssidParts.shift();
-
           ssidParts.forEach(ssidPart => {
             const ssidLines = ssidPart.split(os.EOL);
             if (ssidLines && ssidLines.length >= 8 && ssidLines[0].indexOf(':') >= 0) {
               const bssidsParts = ssidPart.split(' BSSID');
               bssidsParts.shift();
-
               bssidsParts.forEach((bssidPart) => {
-                const bssidLines = bssidPart.split(os.EOL);
+                const bssidLines = bssidPart.split(os.EOL).map(l => l.trim()).filter(Boolean);
+              
+                if (!bssidLines[0] || !bssidLines[0].includes(':')) return;
+              
                 const bssidLine = bssidLines[0].split(':');
                 bssidLine.shift();
                 const bssid = bssidLine.join(':').trim().toLowerCase();
-                const channel = bssidLines[3].split(':').pop().trim();
-                const quality = bssidLines[1].split(':').pop().trim();
-
+              
+                const qualityLine = bssidLines.find(l => /^Signal\s*:/.test(l));
+                const channelLine = bssidLines.find(l => /^Channel\s*:/.test(l));
+              
+                const quality = qualityLine ? qualityLine.split(':').pop().trim() : null;
+                const channel = channelLine ? channelLine.split(':').pop().trim() : null;
+              
+                const securityLine = ssidLines[2] ? ssidLines[2].split(':').pop().trim() : '';
+                const authLine = ssidLines[3] ? ssidLines[3].split(':').pop().trim() : '';
+              
                 result.push({
                   ssid: ssidLines[0].split(':').pop().trim(),
                   bssid,
@@ -489,8 +497,8 @@ function wifiNetworks(callback) {
                   frequency: wifiFrequencyFromChannel(channel),
                   signalLevel: wifiDBFromQuality(quality),
                   quality: quality ? parseInt(quality, 10) : null,
-                  security: [ssidLines[2].split(':').pop().trim()],
-                  wpaFlags: [ssidLines[3].split(':').pop().trim()],
+                  security: securityLine ? [securityLine] : [],
+                  wpaFlags: authLine ? [authLine] : [],
                   rsnFlags: []
                 });
               });


### PR DESCRIPTION
## Note:
I am not using the previously used variable `ssections` because I could not find a reliable way to map any of the displays to the values output. I can go back in and add `pixelDepth` and `main` with the value from the main display in `ssections` as the default for all the monitors. 
## Description
I am opening this pull request because after #853 was submitted I ended up looking at the commands being used to pull the information on windows and noticed that there was some room for improvement. I fixed an issue where in some situations the output would exclude displays. I have also added the fields `displayId` and `productionYear` which was previously only available on MacOS.

## Notable changes
The number of displays is now based on the variable `tsections`. I then match the InstanceName property to the Instance name property in `msections` and `isections`. For `dsections` I am finding the correct display by matching `tsections.InstanceName` to `dsections.PNPDeviceID`

After all of the objects associated with the display have been found the app will then pull variables in this order:
`tsection`
`dsection`
`msection`
and finally `isection`

Since the output of `dsection` is the most complete I pulled what I could from that object first and then went down the list from there. If a variable was not pulled from `dsection` or the correlated object could not be found I would then fill in blank values or pull backup variables from the other objects.

Also:
- Added the fields: `displayId` and `productionYear`

## Examples
 In this situation I am using a RDP connection to a different desktop

Existing module
```JSON
    "displays": [
      {
        "vendor": "",
        "model": "",
        "deviceName": "\\\\.\\DISPLAY17",
        "main": true,
        "builtin": false,
        "connection": "DVI",
        "resolutionX": 2560,
        "resolutionY": 1440,
        "sizeX": 53,
        "sizeY": 30,
        "pixelDepth": 32,
        "currentResX": 2560,
        "currentResY": 1440,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 84
      }
    ]
```
Modified module
```JSON
    "displays": [
      {
        "vendor": "Dell Inc.",
        "deviceName": "Dell E2414H (Digital - DVI)",
        "model": "Dell E2414H",
        "productionYear": 2014,
        "serial": "VMT444ASU",
        "displayId": "DISPLAY\\DEL4091\\5&21dbb09b&0&UID24832_0",
        "main": "",
        "builtin": false,
        "connection": "DVI",
        "sizeX": 53,
        "sizeY": 30,
        "pixelDepth": 0,
        "resolutionX": 2560,
        "resolutionY": 1440,
        "currentResX": 2560,
        "currentResY": 1440,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "D E L",
        "deviceName": "DELL U719D",
        "model": "DELL U719D",
        "productionYear": 2018,
        "serial": "GLQW7R",
        "displayId": "DISPLAY\\DEL415F\\5&21dbb09b&0&UID24833_0",
        "main": "",
        "builtin": false,
        "connection": "HDMI",
        "sizeX": 60,
        "sizeY": 34,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "L E X",
        "deviceName": "A409U",
        "model": "A409U",
        "productionYear": 2015,
        "serial": "16843009",
        "displayId": "DISPLAY\\LEX0000\\5&21dbb09b&0&UID24836_0",
        "main": "",
        "builtin": false,
        "connection": "DP",
        "sizeX": 128,
        "sizeY": 72,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "H W",
        "deviceName": "H V41",
        "model": "H V41",
        "productionYear": 2014,
        "serial": "3CQ4113RS",
        "displayId": "DISPLAY\\HWP311F\\5&21dbb09b&0&UID24839_0",
        "main": "",
        "builtin": false,
        "connection": "DVI",
        "sizeX": 52,
        "sizeY": 29,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "(Standard monitor types)", //Current display 17
        "deviceName": "Generic Non-PnP Monitor",
        "model": "Generic Non-PnP Monitor",
        "productionYear": 0,
        "displayId": "DISPLAY\\Default_Monitor\\1&31c5ecd4&0&UID256_0",
        "main": "",
        "builtin": true,
        "connection": "RDP",
        "sizeX": 0,
        "sizeY": 0,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      }
    ]
```
Without RDP original code:
```JSON
    "displays": [
      {
        "vendor": "Dell Inc.",
        "model": "Dell E2414H (Digital - DVI)",
        "deviceName": "\\\\.\\DISPLAY1",
        "main": false,
        "builtin": false,
        "connection": "DVI",
        "resolutionX": 2560,
        "resolutionY": 1440,
        "sizeX": 53,
        "sizeY": 30,
        "pixelDepth": "32",
        "currentResX": 2560,
        "currentResY": 1440,
        "positionX": -2560,
        "positionY": 740,
        "currentRefreshRate": 84
      },
      {
        "vendor": "",
        "model": "",
        "deviceName": "\\\\.\\DISPLAY2",
        "main": true,
        "builtin": false,
        "connection": "HDMI",
        "resolutionX": 3840,
        "resolutionY": 2160,
        "sizeX": 60,
        "sizeY": 34,
        "pixelDepth": "32",
        "currentResX": 3840,
        "currentResY": 2160,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 84
      },
      {
        "vendor": "",
        "model": "",
        "deviceName": "\\\\.\\DISPLAY3",
        "main": false,
        "builtin": false,
        "connection": "DP",
        "resolutionX": 1920,
        "resolutionY": 1080,
        "sizeX": 128,
        "sizeY": 72,
        "pixelDepth": "32",
        "currentResX": 1920,
        "currentResY": 1080,
        "positionX": 7,
        "positionY": -1080,
        "currentRefreshRate": 84
      },
      {
        "vendor": "",
        "model": "",
        "deviceName": "\\\\.\\DISPLAY4",
        "main": false,
        "builtin": false,
        "connection": "DVI",
        "resolutionX": 1920,
        "resolutionY": 1080,
        "sizeX": 52,
        "sizeY": 29,
        "pixelDepth": "32",
        "currentResX": 1920,
        "currentResY": 1080,
        "positionX": 1927,
        "positionY": -1080,
        "currentRefreshRate": 84
      }
    ]
```
Without RDP modified code:
```JSON
"displays": [
      {
        "vendor": "Dell Inc.",
        "deviceName": "Dell E2414H (Digital - DVI)",
        "model": "Dell E2414H",
        "productionYear": 2014,
        "serial": "VMT444ASU",
        "displayId": "DISPLAY\\DEL4091\\5&21dbb09b&0&UID24832_0",
        "main": "",
        "builtin": false,
        "connection": "DVI",
        "sizeX": 53,
        "sizeY": 30,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "D E L",
        "deviceName": "DELL U719D",
        "model": "DELL U719D",
        "productionYear": 2018,
        "serial": "GLQW7R",
        "displayId": "DISPLAY\\DEL415F\\5&21dbb09b&0&UID24833_0",
        "main": "",
        "builtin": false,
        "connection": "HDMI",
        "sizeX": 60,
        "sizeY": 34,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "L E X",
        "deviceName": "A409U",
        "model": "A409U",
        "productionYear": 2015,
        "serial": "16843009",
        "displayId": "DISPLAY\\LEX0000\\5&21dbb09b&0&UID24836_0",
        "main": "",
        "builtin": false,
        "connection": "DP",
        "sizeX": 128,
        "sizeY": 72,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      },
      {
        "vendor": "H W",
        "deviceName": "H V41",
        "model": "H V41",
        "productionYear": 2014,
        "serial": "3CQ4113RS",
        "displayId": "DISPLAY\\HWP311F\\5&21dbb09b&0&UID24839_0",
        "main": "",
        "builtin": false,
        "connection": "DVI",
        "sizeX": 52,
        "sizeY": 29,
        "pixelDepth": 0,
        "resolutionX": 0,
        "resolutionY": 0,
        "currentResX": 0,
        "currentResY": 0,
        "positionX": 0,
        "positionY": 0,
        "currentRefreshRate": 0
      }
    ]
```
