### PR TITLE
fix(wifi): split nmcli iface by double line

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -147,7 +147,7 @@ function ifaceListLinux() {
   } catch (e) {
     try {
       const all = execSync('nmcli -t -f general,wifi-properties,wired-properties,interface-flags,capabilities,nsp device show 2>/dev/null').toString();
-      const parts = all.split('\nGENERAL.DEVICE:');
+      const parts = all.split('\n\n');
       let i = 1;
       parts.forEach(ifaceDetails => {
         const lines = ifaceDetails.split('\n');
@@ -209,6 +209,9 @@ function nmiConnectionLinux(ssid) {
 }
 
 function wpaConnectionLinux(iface) {
+  if (!iface) {
+    return {};
+  }
   const cmd = `wpa_cli -i ${iface} status 2>&1`;
   try {
     const lines = execSync(cmd).toString().split('\n');


### PR DESCRIPTION
Getting iface by GENERAL.DEVICE is working only for first occurrence, because other parts has already removed the key by split, thus wpa_cli is hanging due to unknown iface.