### PR TITLE
fix(lib-cpu): when trying to obtain other cpu statistics it fails

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -1604,7 +1604,7 @@ function getLoad() {
         // linux: try to get other cpu stats
         if (_linux) {
           try {
-            const lines = execSync('cat /proc/stat 2>/dev/null | grep cpu').split('\n');
+            const lines = execSync('cat /proc/stat 2>/dev/null | grep cpu', {encoding: 'utf8'}).split('\n');
             if (lines.length > 1) {
               lines.shift();
               if (lines.length === cpus.length) {


### PR DESCRIPTION
when trying to get other cpu statistics it fails because the default execSync, its encoding value is a Buffer.
When they want to do the .split('split') it fails and goes through the catch by executing the utility `util.noop();` but it does nothing and generates empty errors in pm2.

Issues https://github.com/sebhildebrandt/systeminformation/issues/862