### PR TITLE
Bugfix: Remove close-handler for powershell child process

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -415,9 +415,6 @@ function powerShellStart() {
       _psChild.on('error', function () {
         powerShellProceedResults(_psResult + _psError);
       });
-      _psChild.on('close', function () {
-        _psChild.kill();
-      });
     }
   }
 }


### PR DESCRIPTION
This PR tries to fix a race condition which occurs when calling powerShellRelease and powerShellStart in sequence.

Background: We need to restart the powershell instance from time to time in a long running process as its memory consumption grows without limit.

Currently, 2 problems can arise in the close-event handler if powerShellStart() is called after powerShellRelease():

1. The variable '_psChild' could be null if the close-event was fired after the null assignment but before the spawn() call returns.
(in my tests when powerShellStart is called 1s after powerShellRelease).

2. The signal from the kill()-call could be delivered to the newly created powershell subprocess.
(in my tests when powerShellStart is called directly after powerShellRelease).

My fix removes the problematic lines, because I don't see a reason for calling 'kill' on the subprocess in its 'close'-event handler.
According to the NodeJS documentation, this handler is called 'after a process has ended and the stdio streams of a child process have been closed'[1]. Maybe I'm missing something here, in that case we could solve the referencing issue using a local variable for the result of 'spawn', use that in the handler and assign the local variable to the global one after setting the handlers.

[1]: https://nodejs.org/api/child_process.html#event-close