### PR TITLE
Fix networkConnections()>darwin IPv6 truncation issue

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -1525,7 +1525,7 @@ function networkConnections(callback) {
       }
       if (_darwin) {
         // let cmd = 'netstat -natv | grep "ESTABLISHED\\|SYN_SENT\\|SYN_RECV\\|FIN_WAIT1\\|FIN_WAIT2\\|TIME_WAIT\\|CLOSE\\|CLOSE_WAIT\\|LAST_ACK\\|LISTEN\\|CLOSING\\|UNKNOWN"';
-        let cmd = 'netstat -natv | grep "tcp4\\|tcp6\\|udp4\\|udp6"';
+        let cmd = 'netstat -natv -ln | grep "tcp4\\|tcp6\\|udp4\\|udp6"';
         const states = 'ESTABLISHED|SYN_SENT|SYN_RECV|FIN_WAIT1|FIN_WAIT2|TIME_WAIT|CLOSE|CLOSE_WAIT|LAST_ACK|LISTEN|CLOSING|UNKNOWN';
         exec(cmd, { maxBuffer: 1024 * 20000 }, function (error, stdout) {
           if (!error) {


### PR DESCRIPTION
Fix `networkConnections()`>darwin longer IPv6 truncation by adding param -ln to netstat command

Before the fix:
```
{
  protocol: 'udp6',
  localAddress: '2600:4040:124f:a',
  localPort: '63082',
  peerAddress: '2607:f8b0:4004:c',
  peerPort: '443',
  state: 'UNKNOWN',
  pid: 72177,
  process: 'Google Chrome Helper'
}
```

After the fix:
```
{
  protocol: 'udp6',
  localAddress: '2600:4040:124f:a100:d0ae:b6ef:b393:f35b',
  localPort: '63082',
  peerAddress: '2607:f8b0:4004:c06::5f',
  peerPort: '443',
  state: 'UNKNOWN',
  pid: 72177,
  process: 'Google Chrome Helper'
}
```