### PR TITLE
WiFi: Get connection info using UUID instead of SSID

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -176,27 +176,26 @@ function nmiDeviceLinux(iface) {
   const cmd = `nmcli -t -f general,wifi-properties,capabilities,ip4,ip6 device show ${iface} 2>/dev/null`;
   try {
     const lines = execSync(cmd).toString().split('\n');
-    const ssid = util.getValue(lines, 'GENERAL.CONNECTION');
     return {
       iface,
       type: util.getValue(lines, 'GENERAL.TYPE'),
       vendor: util.getValue(lines, 'GENERAL.VENDOR'),
       product: util.getValue(lines, 'GENERAL.PRODUCT'),
       mac: util.getValue(lines, 'GENERAL.HWADDR').toLowerCase(),
-      ssid: ssid !== '--' ? ssid : null
+      uuid: util.getValue(lines, 'GENERAL.CON-UUID')
     };
   } catch (e) {
     return {};
   }
 }
 
-function nmiConnectionLinux(ssid) {
-  const cmd = `nmcli -t --show-secrets connection show ${ssid} 2>/dev/null`;
+function nmiConnectionLinux(uuid) {
+  const cmd = `nmcli -t --show-secrets connection show ${uuid} 2>/dev/null`;
   try {
     const lines = execSync(cmd).toString().split('\n');
     const bssid = util.getValue(lines, '802-11-wireless.seen-bssids').toLowerCase();
     return {
-      ssid: ssid !== '--' ? ssid : null,
+      ssid: util.getValue(lines, '802-11-wireless.ssid'),
       uuid: util.getValue(lines, 'connection.uuid'),
       type: util.getValue(lines, 'connection.type'),
       autoconnect: util.getValue(lines, 'connection.autoconnect') === 'yes',
@@ -558,18 +557,9 @@ function wifiConnections(callback) {
 
           const nmiDetails = nmiDeviceLinux(ifaceSanitized);
           const wpaDetails = wpaConnectionLinux(ifaceSanitized);
-          const ssid = nmiDetails.ssid || wpaDetails.ssid;
+          const nmiConnection = nmiConnectionLinux(nmiDetails.uuid);
+          const ssid = nmiConnection.ssid || wpaDetails.ssid;
           const network = networkList.filter(nw => nw.ssid === ssid);
-          let ssidSanitized = '';
-          const t = util.isPrototypePolluted() ? '---' : util.sanitizeShellString(ssid, true);
-          const l = util.mathMin(t.length, 2000);
-          for (let i = 0; i <= l; i++) {
-            if (t[i] !== undefined) {
-              ssidSanitized = ssidSanitized + t[i];
-            }
-          }
-
-          const nmiConnection = nmiConnectionLinux(ssidSanitized);
           const channel = network && network.length && network[0].channel ? network[0].channel : (wpaDetails.channel ? wpaDetails.channel : null);
           const bssid = network && network.length && network[0].bssid ? network[0].bssid : (wpaDetails.bssid ? wpaDetails.bssid : null);
           if (ssid && bssid) {


### PR DESCRIPTION
If you have multiple WiFi interfaces connecting to "YOUR_SSID", the SSID reported back by nmcli might be named "YOUR_SSID \<N\>", where \<N\> is replaced by a digit. While this is in general no problem, this SSID isn't properly "sanitized" (or escaped?) by util.sanitizeShellString() which leads to that YOUR_SSID and \<N\> gets interpreted as separate arguments when passed to nmcli (nmiConnectionLinux()), which in turn makes the information for "YOUR_SSID" to be wrongfully returned.

To avoid the problem of properly escaping the string, just use the UUID for the connection instead for fetching the information, since that should never contain any harmful characters.

(The argument escape problem can probably be solved also by using spawn/spawnSync(), where arguments can be sent as a list instead, and which also returns stdio and stderr as separate objects. Anyhow, perhaps something for the long awaited version 6.)