### PR TITLE
Handle RISC-V CPU Manufacturer and Brand using uarch in /proc/cpuinfo

### DIFF
--- a/lib/cpu.js
+++ b/lib/cpu.js
@@ -605,6 +605,9 @@ function cpuManufacturer(str) {
   if (str.indexOf('Xen') >= 0) { result = 'Xen Hypervisor'; }
   if (str.indexOf('tcg') >= 0) { result = 'QEMU'; }
   if (str.indexOf('apple') >= 0) { result = 'Apple'; }
+  if (str.indexOf('sifive') >= 0) { result = 'SiFive'; }
+  if (str.indexOf('thead') >= 0) { result = 'T-Head'; }
+  if (str.indexOf('andestech') >= 0) { result = 'Andes Technology'; }
 
   return result;
 }
@@ -785,6 +788,17 @@ function getCpu() {
                 result.brand = rPIRevision.processor;
                 result.revision = rPIRevision.revisionCode;
                 result.socket = 'SOC';
+              }
+            }
+
+            // Test RISC-V
+            if (util.getValue(lines, 'architecture') === 'riscv64') {
+              const linesRiscV = fs.readFileSync('/proc/cpuinfo').toString().split('\n');
+              const uarch = util.getValue(linesRiscV, 'uarch') || '';
+              if (uarch.indexOf(',') > -1) {
+                const split = uarch.split(',');
+                result.manufacturer = cpuManufacturer(split[0]);
+                result.brand = split[1];
               }
             }
 


### PR DESCRIPTION
In the RISC-V world, CPUs are often designed by companies like SiFive, T-Head and Andes. Use the /proc/cpuinfo 'uarch' values to get the CPU designer and CPU model.

These designs are then licensed to SoC manufacturers who add I/O and GPU features. For example Allwinner (D1) and StarFive (JH7110), and Sophgo (SG2000)

Tested on my VisionFive2 2 RISC-V board
