### PR TITLE
Add info about USB serial on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,7 +545,7 @@ Full function reference with examples can be found at [https://systeminformation
 |            | [0].manufacturer | X     |     | X   | X   |     | manufacturer             |
 |            | [0].maxPower     | X     |     |     |     |     | max power                |
 |            | [0].default      | X     |     | X   | X   |     | is default printer       |
-|            | [0].serialNumber |       |     | X   |     |     | serial number            |
+|            | [0].serialNumber | X     |     | X   |     |     | serial number            |
 
 #### 11. Printer
 

--- a/lib/usb.js
+++ b/lib/usb.js
@@ -77,6 +77,11 @@ function parseLinuxUsb(usb) {
   iManufacturerParts.shift();
   const manufacturer = iManufacturerParts.join(' ');
 
+  const iSerial = util.getValue(lines, 'iSerial', ' ', true).trim();
+  let iSerialParts = iSerial.split(' ');
+  iSerialParts.shift();
+  const serial = iSerialParts.join(' ');
+
   result.id = (idVendor.startsWith('0x') ? idVendor.split(' ')[0].substr(2, 10) : '') + ':' + (idProduct.startsWith('0x') ? idProduct.split(' ')[0].substr(2, 10) : '');
   result.name = product;
   result.type = getLinuxUsbType(usbType, product);
@@ -84,7 +89,7 @@ function parseLinuxUsb(usb) {
   result.vendor = vendor;
   result.manufacturer = manufacturer;
   result.maxPower = util.getValue(lines, 'MaxPower', ' ', true);
-  result.serialNumber = null;
+  result.serialNumber = serial;
 
   return result;
 }


### PR DESCRIPTION
Get `iSerial` field from `lsusb -v`

Tested on OrangePi5 Ubuntu 20.04 and PC Ubuntu 22.04