### PR TITLE
graphics: optimize getNvidiaSmi()

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -394,8 +394,8 @@ function graphics(callback) {
         const basePath = util.WINDIR + '\\System32\\DriverStore\\FileRepository';
         let newestNvidiaSmi = null;
         for (const dir of fs.readdirSync(basePath)) {
-          // nvidia-smi will only be located in directories starting with `nvdm`.
-          if (!dir.startsWith('nvdm')) continue;
+          // nvidia-smi will only be located in directories starting with `nv`.
+          if (!dir.toLowerCase().startsWith('nv')) continue;
           const path = [basePath, dir, 'nvidia-smi.exe'].join('/');
           const stats = fs.statSync(path, {
             throwIfNoEntry: false

--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -392,19 +392,24 @@ function graphics(callback) {
     if (_windows) {
       try {
         const basePath = util.WINDIR + '\\System32\\DriverStore\\FileRepository';
-        // find all directories that have an nvidia-smi.exe file
-        const candidateDirs = fs.readdirSync(basePath).filter(dir => {
-          return fs.readdirSync([basePath, dir].join('/')).includes('nvidia-smi.exe');
-        });
-        // use the directory with the most recently created nvidia-smi.exe file
-        const targetDir = candidateDirs.reduce((prevDir, currentDir) => {
-          const previousNvidiaSmi = fs.statSync([basePath, prevDir, 'nvidia-smi.exe'].join('/'));
-          const currentNvidiaSmi = fs.statSync([basePath, currentDir, 'nvidia-smi.exe'].join('/'));
-          return (previousNvidiaSmi.ctimeMs > currentNvidiaSmi.ctimeMs) ? prevDir : currentDir;
-        });
+        let newestNvidiaSmi = null;
+        for (const dir of fs.readdirSync(basePath)) {
+          // nvidia-smi will only be located in directories starting with `nvdm`.
+          if (!dir.startsWith('nvdm')) continue;
+          const path = [basePath, dir, 'nvidia-smi.exe'].join('/');
+          const stats = fs.statSync(path, {
+            throwIfNoEntry: false
+          });
+          if (!stats) continue;
+          if (!newestNvidiaSmi) {
+            newestNvidiaSmi = { stats, path };
+          } else if (stats.ctimeMs > newestNvidiaSmi.stats.ctimeMs) {
+            newestNvidiaSmi = { stats, path };
+          }
+        }
 
-        if (targetDir) {
-          _nvidiaSmiPath = [basePath, targetDir, 'nvidia-smi.exe'].join('/');
+        if (newestNvidiaSmi) {
+          _nvidiaSmiPath = newestNvidiaSmi.path;
         }
       } catch (e) {
         util.noop();


### PR DESCRIPTION
narrows down candidate directories smarter, uses stat to check for file existence instead of listing all files in the directory and then checking inside that array, and also avoids calling stat for the same file multiple times.