### PR TITLE
add macOS smartmontools support

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,8 +478,8 @@ Full function reference with examples can be found at [https://systeminformation
 |                      | [0].serialNum         | X     |     | X   | X   |     | serial number                                                            |
 |                      | [0].interfaceType     | X     |     | X   | X   |     | SATA, PCIe, ...                                                          |
 |                      | [0].smartStatus       | X     |     | X   | X   |     | S.M.A.R.T Status (see Known Issues)                                      |
-|                      | [0].temperature       | X     |     |     |     |     | S.M.A.R.T temperature                                                    |
-|                      | [0].smartData         | X     |     |     | X   |     | full S.M.A.R.T data from smartctl<br>requires at least smartmontools 7.0 |
+|                      | [0].temperature       | X     |     | X   |     |     | S.M.A.R.T temperature                                                    |
+|                      | [0].smartData         | X     |     | X   | X   |     | full S.M.A.R.T data from smartctl<br>requires at least smartmontools 7.0 |
 | si.blockDevices(cb)  | [{...}]               | X     |     | X   | X   |     | returns array of disks, partitions,<br>raids and roms                    |
 |                      | [0].name              | X     |     | X   | X   |     | name                                                                     |
 |                      | [0].type              | X     |     | X   | X   |     | type                                                                     |
@@ -960,9 +960,9 @@ In some cases we also discovered that `get-WmiObject` returned incorrect tempera
 In some cases you need to install the Linux `sensors` package to be able to measure temperature
 e.g. on DEBIAN based systems by running `sudo apt-get install lm-sensors`
 
-#### Linux S.M.A.R.T. Status
+#### Linux/macOS S.M.A.R.T. Status
 
-To be able to detect S.M.A.R.T. status on Linux you need to install `smartmontools`. On DEBIAN based Linux distributions you can install it by running `sudo apt-get install smartmontools`
+To be able to detect S.M.A.R.T. status on Linux or macOS you need to install `smartmontools`. On DEBIAN based Linux distributions you can install it by running `sudo apt-get install smartmontools`.  On macOS you can install it via Homebrew by running `brew install smartmontools`.
 
 #### Windows Encoding Issues
 I now reimplemented all windows functions to avoid encoding problems (special chacarters). And as Windows 11 now dropped `wmic` support, I had to move completely to `powershell`. Be sure that powershell version 5+ is installed on your machine. On older Windows versions (7, 8) you might still see encoding problems due to the old powershell version.

--- a/lib/filesystem.js
+++ b/lib/filesystem.js
@@ -1200,6 +1200,7 @@ function diskLayout(callback) {
         resolve(result);
       }
       if (_darwin) {
+        let cmdFullSmart = '';
         exec('system_profiler SPSerialATADataType SPNVMeDataType SPUSBDataType', { maxBuffer: 1024 * 1024 }, function (error, stdout) {
           if (!error) {
             // split by type:
@@ -1257,6 +1258,7 @@ function diskLayout(callback) {
                       BSDName: BSDName
                     });
                     cmd = cmd + 'printf "\n' + BSDName + '|"; diskutil info /dev/' + BSDName + ' | grep SMART;';
+                    cmdFullSmart += `${cmdFullSmart ? 'printf ",";' : ''}smartctl -a -j ${BSDName};`;
                   }
                 }
               });
@@ -1305,6 +1307,7 @@ function diskLayout(callback) {
                       BSDName: BSDName
                     });
                     cmd = cmd + 'printf "\n' + BSDName + '|"; diskutil info /dev/' + BSDName + ' | grep SMART;';
+                    cmdFullSmart += `${cmdFullSmart ? 'printf ",";' : ''}smartctl -a -j ${BSDName};`;
                   }
                 }
               });
@@ -1350,11 +1353,63 @@ function diskLayout(callback) {
                       BSDName: BSDName
                     });
                     cmd = cmd + 'printf "\n' + BSDName + '|"; diskutil info /dev/' + BSDName + ' | grep SMART;';
+                    cmdFullSmart += `${cmdFullSmart ? 'printf ",";' : ''}smartctl -a -j ${BSDName};`;
                   }
                 }
               });
             } catch (e) {
               util.noop();
+            }
+            // check S.M.A.R.T. status
+            if (cmdFullSmart) {
+              exec(cmdFullSmart, { maxBuffer: 1024 * 1024 }, function (error, stdout) {
+                try {
+                  const data = JSON.parse(`[${stdout}]`);
+                  data.forEach(disk => {
+                    const diskBSDName = disk.smartctl.argv[disk.smartctl.argv.length - 1];
+
+                    for (let i = 0; i < result.length; i++) {
+                      if (result[i].BSDName === diskBSDName) {
+                        result[i].smartStatus = (disk.smart_status.passed ? 'Ok' : (disk.smart_status.passed === false ? 'Predicted Failure' : 'unknown'));
+                        if (disk.temperature && disk.temperature.current) {
+                          result[i].temperature = disk.temperature.current;
+                        }
+                        result[i].smartData = disk;
+                      }
+                    }
+                  });
+                  commitResult(result);
+                } catch (e) {
+                  if (cmd) {
+                    cmd = cmd + 'printf "\n"';
+                    exec(cmd, { maxBuffer: 1024 * 1024 }, function (error, stdout) {
+                      let lines = stdout.toString().split('\n');
+                      lines.forEach(line => {
+                        if (line) {
+                          let parts = line.split('|');
+                          if (parts.length === 2) {
+                            let BSDName = parts[0];
+                            parts[1] = parts[1].trim();
+                            let parts2 = parts[1].split(':');
+                            if (parts2.length === 2) {
+                              parts2[1] = parts2[1].trim();
+                              let status = parts2[1].toLowerCase();
+                              for (let i = 0; i < result.length; i++) {
+                                if (result[i].BSDName === BSDName) {
+                                  result[i].smartStatus = (status === 'passed' ? 'Ok' : (status === 'failed!' ? 'Predicted Failure' : 'unknown'));
+                                }
+                              }
+                            }
+                          }
+                        }
+                      });
+                      commitResult(result);
+                    });
+                  } else {
+                    commitResult(result);
+                  }
+                }
+              });
             }
             if (cmd) {
               cmd = cmd + 'printf "\n"';


### PR DESCRIPTION
smartmontools is available on macOS.  In this PR, I just copy and paste the smart code verbatim from Linux to the Darwin conditional branch.

Below is the output of `npm run test` showing the `smartData` field for my 2019-ish iMac's NVMe.

```
SYSTEMINFORMATION - Test Scripts - Version: 5.23.5
═══════════════════════════════════════════════════════════

┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│  a ... Audio              i ... INET Latency       t ... time               1 ... NET Iface Default     ? ... Get Object    │
│  b ... BIOS               I ... INET Check Site    T ... CPU Temperature    2 ... NET Gateway Default   , ... All Static    │
│  B ... Baseboard          j ... CPU Current Speed  u ... USB                3 ... NET Interfaces        . ... All Dynamic   │
│  C ... Chassis            l ... CPU Current Load   U ... UUID               4 ... NET Stats             / ... All           │
│  c ... CPU                L ... Full Load          v ... Versions           5 ... NET Connections                           │
│  d ... DiskLayout         m ... Memory             V ... Virtual Box                                                        │
│  D ... DiskIO             M ... MEM Layout         w ... WIFI networks                                                      │
│  e ... Block Devices      o ... OS Info            W ... WIFI interfaces    6 ... Docker Info                               │
│  E ... Open Files         p ... Processes          x ... WIFI connections   7 ... Docker Images                             │
│  f ... FS Size            P ... Process Load       y ... System             8 ... Docker Container                          │
│  F ... FS Stats           r ... Printer            Y ... Battery            9 ... Docker Cont Stats                         │
│  g ... Graphics           s ... Services           z ... Users              0 ... Docker Cont Proc                          │
│  h ... Bluetooth          S ... Shell                                       + ... Docker Volumes        q >>> QUIT          │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
                                                                      
┌────────────────────────────────────────────────┐
│  Disk Layout                         v: 5.23.5 │
└────────────────────────────────────────────────┘
[
  {
    device: 'disk0',
    type: 'NVMe',
    name: 'APPLE SSD SM2048L',
    vendor: 'Apple',
    size: 2001111162880,
    bytesPerSector: null,
    totalCylinders: null,
    totalHeads: null,
    totalSectors: null,
    totalTracks: null,
    tracksPerCylinder: null,
    sectorsPerTrack: null,
    firmwareRevision: 'CXS7LA0Q',
    serialNum: 'XXXXXXXXXXXXXXXXXXXX',
    interfaceType: 'PCIe x4',
    smartStatus: 'Ok',
    temperature: 33,
    smartData: {
      json_format_version: [ 1, 0 ],
      smartctl: {
        version: [ 7, 4 ],
        pre_release: false,
        svn_revision: '5530',
        platform_info: 'Darwin 24.1.0 x86_64',
        build_info: '(local build)',
        argv: [ 'smartctl', '-a', '-j', 'disk0' ],
        exit_status: 0
      },
      local_time: { time_t: 1727721313, asctime: 'Mon Sep 30 14:35:13 2024 EDT' },
      device: {
        name: 'disk0',
        info_name: 'disk0',
        type: 'nvme',
        protocol: 'NVMe'
      },
      model_name: 'APPLE SSD SM2048L',
      serial_number: 'XXXXXXXXXXXXXXXXXXXXXXXX',
      firmware_version: 'CXS7LA0Q',
      nvme_pci_vendor: { id: 5197, subsystem_id: 5197 },
      nvme_ieee_oui_identifier: 9528,
      nvme_controller_id: 2,
      nvme_version: { string: '<1.2', value: 0 },
      nvme_number_of_namespaces: 1,
      smart_support: { available: true, enabled: true },
      smart_status: { passed: true, nvme: { value: 0 } },
      nvme_smart_health_information_log: {
        critical_warning: 0,
        temperature: 33,
        available_spare: 100,
        available_spare_threshold: 10,
        percentage_used: 2,
        data_units_read: 546637491,
        data_units_written: 272903651,
        host_reads: 15888683017,
        host_writes: 6175519199,
        controller_busy_time: 21850,
        power_cycles: 442,
        power_on_hours: 8149,
        unsafe_shutdowns: 127,
        media_errors: 0,
        num_err_log_entries: 0
      },
      temperature: { current: 33 },
      power_cycle_count: 442,
      power_on_time: { hours: 8149 },
      nvme_error_information_log: { size: 64, read: 16, unread: 0 }
    }
  },
  {
    device: 'disk2',
    type: 'USB',
    name: 'Micron_1100_MTFD',
    vendor: '',
    size: 2048408248320,
    bytesPerSector: null,
    totalCylinders: null,
    totalHeads: null,
    totalSectors: null,
    totalTracks: null,
    tracksPerCylinder: null,
    sectorsPerTrack: null,
    firmwareRevision: '',
    serialNum: '0123456789ABCDE',
    interfaceType: 'USB',
    smartStatus: 'not supported',
    temperature: null
  }
]
Time to complete: 1.066s
```