### PR TITLE
Add support for wifi networks on MacOS > 14.4

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -14,8 +14,9 @@
 // ----------------------------------------------------------------------------------
 
 const os = require('os');
-const exec = require('child_process').exec;
-const execSync = require('child_process').execSync;
+const cp = require('child_process');
+const exec = cp.exec;
+const execSync = cp.execSync;
 const util = require('./util');
 
 let _platform = process.platform;
@@ -347,53 +348,49 @@ function getWifiNetworkListIw(iface) {
 
 function parseWifiDarwin(wifiObj) {
   const result = [];
-  if (wifiObj) {
-    wifiObj.forEach(function (wifiItem) {
-      const signalLevel = wifiItem.RSSI;
-      let security = [];
-      let wpaFlags = [];
-      let ssid = wifiItem.SSID_STR || '';
-      if (wifiItem.WPA_IE) {
-        security.push('WPA');
-        if (wifiItem.WPA_IE.IE_KEY_WPA_UCIPHERS) {
-          wifiItem.WPA_IE.IE_KEY_WPA_UCIPHERS.forEach(function (ciphers) {
-            if (ciphers === 0 && wpaFlags.indexOf('unknown/TKIP') === -1) { wpaFlags.push('unknown/TKIP'); }
-            if (ciphers === 2 && wpaFlags.indexOf('PSK/TKIP') === -1) { wpaFlags.push('PSK/TKIP'); }
-            if (ciphers === 4 && wpaFlags.indexOf('PSK/AES') === -1) { wpaFlags.push('PSK/AES'); }
-          });
-        }
-      }
-      if (wifiItem.RSN_IE) {
-        security.push('WPA2');
-        if (wifiItem.RSN_IE.IE_KEY_RSN_UCIPHERS) {
-          wifiItem.RSN_IE.IE_KEY_RSN_UCIPHERS.forEach(function (ciphers) {
-            if (ciphers === 0 && wpaFlags.indexOf('unknown/TKIP') === -1) { wpaFlags.push('unknown/TKIP'); }
-            if (ciphers === 2 && wpaFlags.indexOf('TKIP/TKIP') === -1) { wpaFlags.push('TKIP/TKIP'); }
-            if (ciphers === 4 && wpaFlags.indexOf('PSK/AES') === -1) { wpaFlags.push('PSK/AES'); }
-          });
-        }
-      }
-      if (wifiItem.SSID && ssid === '') {
-        try {
-          ssid = Buffer.from(wifiItem.SSID, 'base64').toString('utf8');
-        } catch (err) {
-          util.noop();
-        }
-      }
-      result.push({
-        ssid,
-        bssid: wifiItem.BSSID || '',
-        mode: '',
-        channel: wifiItem.CHANNEL,
-        frequency: wifiFrequencyFromChannel(wifiItem.CHANNEL),
-        signalLevel: signalLevel ? parseInt(signalLevel, 10) : null,
-        quality: wifiQualityFromDB(signalLevel),
-        security,
-        wpaFlags,
-        rsnFlags: []
-      });
-    });
+  if (!wifiObj || wifiObj.length === 0) {
+    return result;
   }
+  const items = wifiObj[0]._items;
+  if (!items) {
+    return result;
+  }
+  const networks = items.flatMap((i) => i.spairport_airport_interfaces).flatMap((iface) => iface.spairport_airport_other_local_wireless_networks);
+  networks.forEach(function (wifiItem) {
+    if (!wifiItem) {
+      return;
+    }
+    let security = [];
+    const sm = wifiItem.spairport_security_mode;
+    if (sm === 'spairport_security_mode_wep') {
+      security.push('WEP');
+    } else if (sm === 'spairport_security_mode_wpa2_personal')  {
+      security.push('WPA2');
+    } else if (sm.startsWith('spairport_security_mode_wpa2_enterprise'))  {
+      // Covers both spairport_security_mode_wpa2_enterprise and spairport_security_mode_wpa2_enterprise_mixed
+      security.push('WPA2 EAP');
+    } else if (sm.startsWith('pairport_security_mode_wpa3_transition'))  {
+      security.push('WPA2/WPA3');
+    } else if (sm.startsWith('pairport_security_mode_wpa3'))  {
+      // this is just guessed
+      security.push('WPA3');
+    }
+
+    const channelInfo = new RegExp(/(\d+) \((\d)GHz, (\d+)MHz\)/g).exec(wifiItem.spairport_network_channel);
+
+    result.push({
+      ssid: wifiItem._name,
+      bssid: '',
+      mode: wifiItem.spairport_network_phymode,
+      channel: channelInfo[1],
+      frequency: wifiFrequencyFromChannel(channelInfo[1]),
+      signalLevel: null,
+      quality: null,
+      security,
+      wpaFlags: [],
+      rsnFlags: []
+    });
+  });
   return result;
 }
 function wifiNetworks(callback) {
@@ -459,7 +456,7 @@ function wifiNetworks(callback) {
           resolve(result);
         }
       } else if (_darwin) {
-        let cmd = '/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -s -x';
+        let cmd = 'system_profiler -xml SPAirPortDataType';
         exec(cmd, { maxBuffer: 1024 * 40000 }, function (error, stdout) {
           const output = stdout.toString();
           result = parseWifiDarwin(util.plistParser(output));


### PR DESCRIPTION
Instead of using the deprecated airport command, utilise system_profiler to inspect available networks. Even though this does not have all the information, which were provided by airport.

All fields are still present in the response to maintain backwards compatibility.

Fixes: #912 