### PR TITLE
Extend type definitions with overload `fsSize(cb)`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -981,6 +981,7 @@ export function battery(cb?: (data: Systeminformation.BatteryData) => any): Prom
 export function graphics(cb?: (data: Systeminformation.GraphicsData) => any): Promise<Systeminformation.GraphicsData>;
 
 export function fsSize(drive?: string, cb?: (data: Systeminformation.FsSizeData[]) => any): Promise<Systeminformation.FsSizeData[]>;
+export function fsSize(cb?: (data: Systeminformation.FsSizeData[]) => any): Promise<Systeminformation.FsSizeData[]>;
 export function fsOpenFiles(cb?: (data: Systeminformation.FsOpenFilesData[]) => any): Promise<Systeminformation.FsOpenFilesData[]>;
 export function blockDevices(cb?: (data: Systeminformation.BlockDevicesData[]) => any): Promise<Systeminformation.BlockDevicesData[]>;
 export function fsStats(cb?: (data: Systeminformation.FsStatsData) => any): Promise<Systeminformation.FsStatsData>;


### PR DESCRIPTION
The `drive` parameter in `fsSize` is optional, as documented in the changelog for v5 and validated through observation of the underlying implementation. The overload in this PR clarifies type checkers that `fsSize` can be called with just the callback parameter, unlike what is conveyed by the existing declaration `fsSize(string, cb)`.
