### PR TITLE
Trim and sanitize SSD name to avoid potentially executing code from an AP with a malicious name

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -348,7 +348,7 @@ function getWindowsWirelessIfaceSSID(interfaceName) {
   try {
     const result = execSync(`netsh wlan show  interface name="${interfaceName}" | findstr "SSID"`, util.execOptsWin);
     const SSID = result.split('\r\n').shift();
-    const parseSSID = SSID.split(':').pop();
+    const parseSSID = SSID.split(':').pop().trim();
     return parseSSID;
   } catch (error) {
     return 'Unknown';
@@ -400,8 +400,16 @@ function getWindowsIEEE8021x(connectionType, iface, ifaces) {
     try {
       const SSID = getWindowsWirelessIfaceSSID(iface);
       if (SSID !== 'Unknown') {
-        i8021xState = execSync(`netsh wlan show profiles "${SSID}" | findstr "802.1X"`, util.execOptsWin);
-        i8021xProtocol = execSync(`netsh wlan show profiles "${SSID}" | findstr "EAP"`, util.execOptsWin);
+        let sanitizedSSID = '';
+        const s = util.isPrototypePolluted() ? '---' : util.sanitizeShellString(SSID);
+        const l = util.mathMin(s.length, 2000);
+        for (let i = 0; i <= l; i++) {
+          if (s[i] !== undefined) {
+            sanitizedSSID = sanitizedSSID + s[i];
+          }
+        }
+        i8021xState = execSync(`netsh wlan show profiles "${sanitizedSSID}" | findstr "802.1X"`, util.execOptsWin);
+        i8021xProtocol = execSync(`netsh wlan show profiles "${sanitizedSSID}" | findstr "EAP"`, util.execOptsWin);
       }
 
       if (i8021xState.includes(':') && i8021xProtocol.includes(':')) {


### PR DESCRIPTION
Hello!

I noticed an issue in systeminformation where under various circumstances the SSID for wireless networks can get passed raw to the CLI creating an injection vulnerability. I created a small patch to prevent this by sanitizing the SSID before trying to look up  more details about it.

Thanks,
-Nicholas