### PR TITLE
Raspberry: fix Baseboard and Mem Layout check

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -401,11 +401,9 @@ function memLayout(callback) {
             try {
               let stdout = execSync('cat /proc/cpuinfo 2>/dev/null', util.execOptsLinux);
               let lines = stdout.toString().split('\n');
-              let model = util.getValue(lines, 'hardware', ':', true).toUpperCase();
               let version = util.getValue(lines, 'revision', ':', true).toLowerCase();
 
-              if (model === 'BCM2835' || model === 'BCM2708' || model === 'BCM2709' || model === 'BCM2835' || model === 'BCM2837') {
-
+              if (util.isRaspberry()) {
                 const clockSpeed = {
                   '0': 400,
                   '1': 450,

--- a/lib/system.js
+++ b/lib/system.js
@@ -183,13 +183,10 @@ function system(callback) {
             fs.readFile('/proc/cpuinfo', function (error, stdout) {
               if (!error) {
                 let lines = stdout.toString().split('\n');
-                result.model = util.getValue(lines, 'hardware', ':', true).toUpperCase();
                 result.version = util.getValue(lines, 'revision', ':', true).toLowerCase();
                 result.serial = util.getValue(lines, 'serial', ':', true);
                 const model = util.getValue(lines, 'model:', ':', true);
-                // reference values: https://elinux.org/RPi_HardwareHistory
-                // https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
-                if ((result.model === 'BCM2835' || result.model === 'BCM2708' || result.model === 'BCM2709' || result.model === 'BCM2710' || result.model === 'BCM2711' || result.model === 'BCM2836' || result.model === 'BCM2837' || result.model === '') && model.toLowerCase().indexOf('raspberry') >= 0) {
+                if (util.isRaspberry()) {
                   const rPIRevision = util.decodePiCpuinfo(lines);
                   result.model = rPIRevision.model;
                   result.version = rPIRevision.revisionCode;
@@ -511,8 +508,7 @@ function baseboard(callback) {
             util.noop();
           }
           if (linesRpi) {
-            const hardware = util.getValue(linesRpi, 'hardware');
-            if (hardware.startsWith('BCM')) {
+            if (util.isRaspberry()) {
               const rpi = util.decodePiCpuinfo(linesRpi);
               result.manufacturer = rpi.manufacturer;
               result.model = 'Raspberry Pi';

--- a/lib/util.js
+++ b/lib/util.js
@@ -636,6 +636,8 @@ function smartMonToolsInstalled() {
 }
 
 function isRaspberry() {
+  // reference values: https://elinux.org/RPi_HardwareHistory
+  // https://www.raspberrypi.org/documentation/hardware/raspberrypi/revision-codes/README.md
   const PI_MODEL_NO = [
     'BCM2708',
     'BCM2709',


### PR DESCRIPTION
### context

due to the upstream issue https://github.com/raspberrypi/linux/issues/2110, the `/proc/cpuinfo` on Raspberry 64-bit OS no longer populate the line beginning with `hardware`, which breaks this repo's assumption.

### the fix logic

for 64-bit OS, read `/proc/device-tree/compatible` instead and get the SOC string for the rpi devices

### test

before the fix, with the command `si.system()`

I get 

```
{
  manufacturer: '',
  model: '',
  version: 'c03111',
  serial: '{omitted}',
  uuid: '',
  sku: '-',
  virtual: false
}
```

after the fix 

I get 

```
{
  manufacturer: 'Raspberry Pi Foundation',
  model: 'Raspberry Pi 4 Model B Rev 1.1',
  version: 'c03111',
  serial: '{omitted}',
  uuid: '',
  sku: '-',
  virtual: false,
  raspberry: {
    manufacturer: 'Sony UK',
    processor: 'BCM2711',
    type: '4B',
    revision: '1.1'
  }
}
```

this PR should be able to fix https://github.com/sebhildebrandt/systeminformation/issues/881
