### PR TITLE
memory() unify RAM manufacturers and include Windows to parse

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -29,22 +29,7 @@ const _openbsd = (_platform === 'openbsd');
 const _netbsd = (_platform === 'netbsd');
 const _sunos = (_platform === 'sunos');
 
-const OSX_RAM_manufacturers = {
-  '0x014F': 'Transcend Information',
-  '0x2C00': 'Micron Technology Inc.',
-  '0x802C': 'Micron Technology Inc.',
-  '0x80AD': 'Hynix Semiconductor Inc.',
-  '0x80CE': 'Samsung Electronics Inc.',
-  '0xAD00': 'Hynix Semiconductor Inc.',
-  '0xCE00': 'Samsung Electronics Inc.',
-  '0x02FE': 'Elpida',
-  '0x5105': 'Qimonda AG i. In.',
-  '0x8551': 'Qimonda AG i. In.',
-  '0x859B': 'Crucial',
-  '0x04CD': 'G-Skill'
-};
-
-const LINUX_RAM_manufacturers = {
+const RAM_manufacturers = {
   '017A': 'Apacer',
   '0198': 'HyperX',
   '029E': 'Corsair',
@@ -315,17 +300,10 @@ exports.mem = mem;
 
 function memLayout(callback) {
 
-  function getManufacturerDarwin(manId) {
-    if ({}.hasOwnProperty.call(OSX_RAM_manufacturers, manId)) {
-      return (OSX_RAM_manufacturers[manId]);
-    }
-    return manId;
-  }
-
-  function getManufacturerLinux(manId) {
+  function getManufacturer(manId) {
     const manIdSearch = manId.replace('0x', '').toUpperCase();
-    if (manIdSearch.length === 4 && {}.hasOwnProperty.call(LINUX_RAM_manufacturers, manIdSearch)) {
-      return (LINUX_RAM_manufacturers[manIdSearch]);
+    if (manIdSearch.length === 4 && {}.hasOwnProperty.call(RAM_manufacturers, manIdSearch)) {
+      return (RAM_manufacturers[manIdSearch]);
     }
     return manId;
   }
@@ -358,7 +336,7 @@ function memLayout(callback) {
                   ecc: dataWidth && totalWidth ? totalWidth > dataWidth : false,
                   clockSpeed: (util.getValue(lines, 'Configured Clock Speed:') ? parseInt(util.getValue(lines, 'Configured Clock Speed:'), 10) : (util.getValue(lines, 'Speed:') ? parseInt(util.getValue(lines, 'Speed:'), 10) : null)),
                   formFactor: util.getValue(lines, 'Form Factor:'),
-                  manufacturer: getManufacturerLinux(util.getValue(lines, 'Manufacturer:')),
+                  manufacturer: getManufacturer(util.getValue(lines, 'Manufacturer:')),
                   partNum: util.getValue(lines, 'Part Number:'),
                   serialNum: util.getValue(lines, 'Serial Number:'),
                   voltageConfigured: parseFloat(util.getValue(lines, 'Configured Voltage:')) || null,
@@ -470,7 +448,7 @@ function memLayout(callback) {
                   ecc: eccStatus ? eccStatus === 'enabled' : null,
                   clockSpeed: parseInt(util.getValue(lines, '          Speed:'), 10),
                   formFactor: '',
-                  manufacturer: getManufacturerDarwin(util.getValue(lines, '          Manufacturer:')),
+                  manufacturer: getManufacturer(util.getValue(lines, '          Manufacturer:')),
                   partNum: util.getValue(lines, '          Part Number:'),
                   serialNum: util.getValue(lines, '          Serial Number:'),
                   voltageConfigured: null,
@@ -508,7 +486,7 @@ function memLayout(callback) {
                 ecc: false,
                 clockSpeed: null,
                 formFactor: 'SOC',
-                manufacturer: getManufacturerDarwin(manufacturerId),
+                manufacturer: getManufacturer(manufacturerId),
                 partNum: '',
                 serialNum: '',
                 voltageConfigured: null,
@@ -551,7 +529,7 @@ function memLayout(callback) {
                     ecc: dataWidth && totalWidth ? totalWidth > dataWidth : false,
                     clockSpeed: parseInt(util.getValue(lines, 'ConfiguredClockSpeed', ':'), 10) || parseInt(util.getValue(lines, 'Speed', ':'), 10) || 0,
                     formFactor: FormFactors[parseInt(util.getValue(lines, 'FormFactor', ':'), 10) || 0],
-                    manufacturer: util.getValue(lines, 'Manufacturer', ':'),
+                    manufacturer: getManufacturer(util.getValue(lines, 'Manufacturer', ':')),
                     partNum: util.getValue(lines, 'PartNumber', ':'),
                     serialNum: util.getValue(lines, 'SerialNumber', ':'),
                     voltageConfigured: (parseInt(util.getValue(lines, 'ConfiguredVoltage', ':'), 10) || 0) / 1000.0,
@@ -574,4 +552,3 @@ function memLayout(callback) {
 }
 
 exports.memLayout = memLayout;
-


### PR DESCRIPTION
1. Devices that use hex-based identification can use Windows, such as MacBooks.
2. The OSX and Linux RAM manufacturer list are redundant, which can and should be unified. 

I opted to use the manufacturer parsing done for Linux as that method has a higher chance of catching applicable manufacturers/

An example output from my MacBook Pro 2013 on Windows 11 24H2:

## Before
```
"memLayout": [
    {
      "size": 4294967296,
      "bank": "BANK 0/0",
      "type": "DDR3",
      "ecc": false,
      "clockSpeed": 1600,
      "formFactor": "SODIMM",
      "manufacturer": "0x02FE",
      "partNum": "0x45424A3431554638424455302D474E2D4620",
      "serialNum": "0",
      "voltageConfigured": 0,
      "voltageMin": 0,
      "voltageMax": 0
    },
    {
      "size": 4294967296,
      "bank": "BANK 1/1",
      "type": "DDR3",
      "ecc": false,
      "clockSpeed": 1600,
      "formFactor": "SODIMM",
      "manufacturer": "0x02FE",
      "partNum": "0x45424A3431554638424455302D474E2D4620",
      "serialNum": "0",
      "voltageConfigured": 0,
      "voltageMin": 0,
      "voltageMax": 0
    }
  ],
```

## After
```
"memLayout": [
    {
      "size": 4294967296,
      "bank": "BANK 0/0",
      "type": "DDR3",
      "ecc": false,
      "clockSpeed": 1600,
      "formFactor": "SODIMM",
      "manufacturer": "Elpida",
      "partNum": "0x45424A3431554638424455302D474E2D4620",
      "serialNum": "0",
      "voltageConfigured": 0,
      "voltageMin": 0,
      "voltageMax": 0
    },
    {
      "size": 4294967296,
      "bank": "BANK 1/1",
      "type": "DDR3",
      "ecc": false,
      "clockSpeed": 1600,
      "formFactor": "SODIMM",
      "manufacturer": "Elpida",
      "partNum": "0x45424A3431554638424455302D474E2D4620",
      "serialNum": "0",
      "voltageConfigured": 0,
      "voltageMin": 0,
      "voltageMax": 0
    }
  ],
```