### PR TITLE
graphics() alternative nvidia-smi check

### DIFF
--- a/lib/graphics.js
+++ b/lib/graphics.js
@@ -391,20 +391,28 @@ function graphics(callback) {
 
     if (_windows) {
       try {
-        const basePath = util.WINDIR + '\\System32\\DriverStore\\FileRepository';
-        // find all directories that have an nvidia-smi.exe file
-        const candidateDirs = fs.readdirSync(basePath).filter(dir => {
-          return fs.readdirSync([basePath, dir].join('/')).includes('nvidia-smi.exe');
-        });
-        // use the directory with the most recently created nvidia-smi.exe file
-        const targetDir = candidateDirs.reduce((prevDir, currentDir) => {
-          const previousNvidiaSmi = fs.statSync([basePath, prevDir, 'nvidia-smi.exe'].join('/'));
-          const currentNvidiaSmi = fs.statSync([basePath, currentDir, 'nvidia-smi.exe'].join('/'));
-          return (previousNvidiaSmi.ctimeMs > currentNvidiaSmi.ctimeMs) ? prevDir : currentDir;
-        });
+        const symlinkedPath = `${util.WINDIR}\\System32\\nvidia-smi.exe`;
+        if (fs.existsSync(symlinkedPath)) { 
+          _nvidiaSmiPath = symlinkedPath;
+        } else { 
+          // As a last resort, scan the Driver Store.
+          // This shouldn't be necessary unless another program somehow tampers with the symlink (example another program as TrustedInstaller renames or deletes the symlinked file).
+          const basePath = `${util.WINDIR}\\System32\\DriverStore\\FileRepository`;
 
-        if (targetDir) {
-          _nvidiaSmiPath = [basePath, targetDir, 'nvidia-smi.exe'].join('/');
+          const driverStoreSmiPath = fs.readdirSync(basePath).reduce((newest, dir) => {
+            if (!dir.toLowerCase().startsWith('nv')) return newest;
+            const path = [basePath, dir, 'nvidia-smi.exe'].join('/');
+            const stats = fs.statSync(path, { throwIfNoEntry: false });
+            if (!stats) return newest;
+            if (!newest || stats.ctimeMs > newest.stats.ctimeMs) {
+              return { stats, path };
+            }
+            return newest;
+          }, null);
+        
+          if (driverStoreSmiPath) {
+            _nvidiaSmiPath = driverStoreSmiPath.path;
+          }
         }
       } catch (e) {
         util.noop();


### PR DESCRIPTION
This PR is more or less to get movement from #927 and #928

This aims to address a few things:

1. Start with using the nvidia-smi symlinked path as a measure to avoid needing to scan the Driver Store.
2. On a typical Windows installation with an NVIDIA graphics driver properly installed, the NVIDIA SMI symlink should never get tampered with unless an external program decides to do otherwise. While rare, if the symlink path somehow doesn't exist, the Driver Store scan will then happen
3. Regarding the Driver Store scan, this mostly incorporates the changes made in #927, but further condenses. #927 also addresses an issue with the current main implementation where if a non-directory is parsed, an error would then be thrown and the scan would terminate without the nvidia-smi ever being found.

I noticed in commit https://github.com/sebhildebrandt/systeminformation/commit/e67aa92d56c818176335cf867d5465614617730c that checking if a file or folder starts with `nv` was omitted. Fro my testing, and some friends, and the results in the conversation #927, this seems like this should have been fine to keep but then again the results I see is still a small sample size. If there was a reason why this was omitted originally that would be helpful to get movement on this PR.

Few ways this could go around:
1. PR remains as is and should be good to go with both the fast path check and the driver store scan. I'm not too worried if this remains as is since the likelihood of the driver store scan ever being necessary is absolutely low unless the symlink *somehow* never gets created or gets tampered with.
2. Omit the driver scan altogether, which would align with https://github.com/sebhildebrandt/systeminformation/pull/927#issuecomment-2295408218. I would agree with this move partially aside from the fact that the nvidia-smi *can* get tampered with by any application with the right permissions so having the driver store scan as a fallback I feel is fine.
3. Don't include the System32 symlinked path. This I would highly disagree with as if the driver store scan is the only portion that determines if an NVIDIA-SMI executable path exists will absolutely take up a huge amount of resources, especially with the Driver Store likely containing 700+ items. Sure, this PR will definitely lessen the amount of resources used compared to what is currently available (that is assuming the scan never encounters a non-directory).