### PR TITLE
Update wifi.js to still include networks with missing security mode on macos

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -406,16 +406,18 @@ function parseWifiDarwin(wifiStr) {
 
       let security = [];
       const sm = wifiItem.spairport_security_mode;
-      if (sm === 'spairport_security_mode_wep') {
-        security.push('WEP');
-      } else if (sm === 'spairport_security_mode_wpa2_personal') {
-        security.push('WPA2');
-      } else if (sm.startsWith('spairport_security_mode_wpa2_enterprise')) {
-        security.push('WPA2 EAP');
-      } else if (sm.startsWith('pairport_security_mode_wpa3_transition')) {
-        security.push('WPA2/WPA3');
-      } else if (sm.startsWith('pairport_security_mode_wpa3')) {
-        security.push('WPA3');
+      if (sm != null) {
+        if (sm === 'spairport_security_mode_wep') {
+          security.push('WEP');
+        } else if (sm === 'spairport_security_mode_wpa2_personal') {
+          security.push('WPA2');
+        } else if (sm.startsWith('spairport_security_mode_wpa2_enterprise')) {
+          security.push('WPA2 EAP');
+        } else if (sm.startsWith('pairport_security_mode_wpa3_transition')) {
+          security.push('WPA2/WPA3');
+        } else if (sm.startsWith('pairport_security_mode_wpa3')) {
+          security.push('WPA3');
+        }
       }
       const channel = parseInt(('' + wifiItem.spairport_network_channel).split(' ')[0]) || 0;
       const signalLevel = wifiItem.spairport_signal_noise || null;


### PR DESCRIPTION
`wifiNetworks` will on return a subset of networks if one of the networks in the list returned by the macos command does not have a security mode.

Before, only 11 of 19 get processed:
![CleanShot 2025-01-28 at 17 08 01 2@2x](https://github.com/user-attachments/assets/f9c831aa-f30e-4e26-bc32-3cf546e42183)
After, 19 of 19 get processed:
![CleanShot 2025-01-28 at 17 20 24@2x](https://github.com/user-attachments/assets/88ea35b9-e207-482d-ad67-bad953faf3e7)
