### PR TITLE
Improve TS typings for `networkInterfaces`

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -991,8 +991,12 @@ export function diskLayout(cb?: (data: Systeminformation.DiskLayoutData[]) => an
 
 export function networkInterfaceDefault(cb?: (data: string) => any): Promise<string>;
 export function networkGatewayDefault(cb?: (data: string) => any): Promise<string>;
+
+export function networkInterfaces(): Promise<Systeminformation.NetworkInterfacesData[]>;
+export function networkInterfaces(defaultString: 'default'): Promise<Systeminformation.NetworkInterfacesData>;
+export function networkInterfaces(rescan: boolean): Promise<Systeminformation.NetworkInterfacesData[]>;
 export function networkInterfaces(
-  cb?:
+  cb:
     | ((data: Systeminformation.NetworkInterfacesData[] | Systeminformation.NetworkInterfacesData) => any)
     | boolean
     | string,


### PR DESCRIPTION
The `networkInterfaces` function normally returns an array, but when passed the string `default` it will return only a single `NetworkInterfacesData` object.

This variability makes the current TS types frustrating to use, because you'll need to cast the result or check the result at runtime to use it without the TS compiler complaining. This work is unnecessary, because the shape of the parameters (available to TS at compile time) determines the type of the results.

This PR adds three overloads for the most common 0-1 parameter cases so that the return types won't need casts. The existing declaration is left as-is (other than making the first parameter required because the zero-parameter case is already handled with an overload) to handle more complex cases with callback functions or more than one parameter.