### PR TITLE
inetChecksite() fix unknown method on timeout

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2538,7 +2538,7 @@ function checkWebsite(url, timeout = 5000) {
         });
       })
       .setTimeout(timeout, () => {
-        request.close();
+        request.destroy();
         resolve({
           url,
           statusCode: 408,


### PR DESCRIPTION
This PR is the fix for #982. Currently, inetTimeout uses `request.close()` when the request times out, which is not a valid method according to the [docs](https://nodejs.org/api/http.html#class-httpclientrequest), leading to a `TypeError` (see issue for full trace).

This PR uses the correct [request.destroy()](https://nodejs.org/api/http.html#requestdestroyerror) to clean up the request in case of a timeout. 