### PR TITLE
fix: correctly type `fsOpenFiles` return value

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -984,7 +984,7 @@ export function graphics(cb?: (data: Systeminformation.GraphicsData) => any): Pr
 
 export function fsSize(drive?: string, cb?: (data: Systeminformation.FsSizeData[]) => any): Promise<Systeminformation.FsSizeData[]>;
 export function fsSize(cb?: (data: Systeminformation.FsSizeData[]) => any): Promise<Systeminformation.FsSizeData[]>;
-export function fsOpenFiles(cb?: (data: Systeminformation.FsOpenFilesData[]) => any): Promise<Systeminformation.FsOpenFilesData[]>;
+export function fsOpenFiles(cb?: (data: Systeminformation.FsOpenFilesData) => any): Promise<Systeminformation.FsOpenFilesData>;
 export function blockDevices(cb?: (data: Systeminformation.BlockDevicesData[]) => any): Promise<Systeminformation.BlockDevicesData[]>;
 export function fsStats(cb?: (data: Systeminformation.FsStatsData) => any): Promise<Systeminformation.FsStatsData>;
 export function disksIO(cb?: (data: Systeminformation.DisksIoData) => any): Promise<Systeminformation.DisksIoData>;


### PR DESCRIPTION
This PR fixes the type for the `fsOpenFiles` function.

If you check the implementation, the function returns:
```js
const result = {
  max: null,
  allocated: null,
  available: null
};
 ```
which is not an array.