### PR TITLE
feat: add spibridgedatatype to bios information

### DIFF
--- a/lib/system.js
+++ b/lib/system.js
@@ -418,17 +418,17 @@ function bios(callback) {
               util.noop();
             }
             exec('system_profiler SPiBridgeDataType -json', function (_errorSpi, stdoutSpi) {
-            try {
-              const spiBridgeData = JSON.parse(stdoutSpi.toString());
-              if (spiBridgeData) {
-                result.SPiBridgeDataType = spiBridgeData;
+              try {
+                const spiBridgeData = JSON.parse(stdoutSpi.toString());
+                if (spiBridgeData) {
+                  result.SPiBridgeDataType = spiBridgeData;
+                }
+              } catch (e) {
+                util.noop();
               }
-            } catch (e) {
-              util.noop();
-            }
-            if (callback) { callback(result); }
-            resolve(result);
-          });
+              if (callback) { callback(result); }
+              resolve(result);
+            });
         });
       }
       if (_sunos) {


### PR DESCRIPTION
Hello!

I'm currently using systeminformation to get information in Ubuntu, MacOS and Windows devices and I'm loving it. Nonetheless I need to get more information about BIOS in MacOS devices, specifically security chip in older MacOS devices. I was thinking of just calling it from my code, but I think it's better if we extend systeminformation to get it.

I opted for using:

`system_profiler SPiBridgeDataType -json`

after the execution of the code to get `SPHardwareDataType` in Darwin and following the type of coding I saw in the original file. That adds to the `result` object if everthing went well and then it should resolve itself or call the callback function (if callback is a function really haha).

Let me know if everything seems to be fine and if this helps you in any way. I would be glad if you can add this to the next release :)!