### PR TITLE
fix: add UTF-8 encoding prefix for PowerShell on Windows 10+

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -479,7 +479,7 @@ function powerShell(cmd) {
           const spanOptions =
             osVersion[0] < 10
               ? ['-NoProfile', '-NoLogo', '-InputFormat', 'Text', '-NoExit', '-ExecutionPolicy', 'Unrestricted', '-Command', '-']
-              : ['-NoProfile', '-NoLogo', '-InputFormat', 'Text', '-ExecutionPolicy', 'Unrestricted', '-Command', cmd];
+              : ['-NoProfile', '-NoLogo', '-InputFormat', 'Text', '-ExecutionPolicy', 'Unrestricted', '-Command', _psToUTF8 + cmd];
           const child = spawn(_powerShell, spanOptions, {
             stdio: 'pipe',
             windowsHide: true,


### PR DESCRIPTION
Windows 10+ PowerShell commands were missing the UTF-8 encoding setup that already exists in the Windows 7 code path, causing garbled text for Chinese, Japanese, Korean and other non-ASCII characters.

Before: Microsoft Windows 11 רҵ��
After:  Microsoft Windows 11 专业版

This adds the _psToUTF8 prefix (line 482) to align Windows 10+ behavior with the existing Windows 7 implementation, ensuring correct character encoding across all Windows versions.

Tested on Windows 11 Chinese (CP936) with PowerShell 5.1 and 7.x