### PR TITLE
Support Uppercase Letters in Linux Network Interface Names

### DIFF
--- a/lib/network.js
+++ b/lib/network.js
@@ -947,7 +947,7 @@ function networkInterfaces(callback, rescan, defaultString) {
                 ip6 = ip6link;
                 ip6subnet = ip6linksubnet;
               }
-              const iface = dev.split(':')[0].trim().toLowerCase();
+              const iface = dev.split(':')[0].trim();
               let ifaceSanitized = '';
               const s = util.isPrototypePolluted() ? '---' : util.sanitizeShellString(iface);
               const l = util.mathMin(s.length, 2000);
@@ -1290,7 +1290,7 @@ function networkStats(ifaces, callback) {
           Object.setPrototypeOf(ifaces, util.stringObj);
         }
 
-        ifaces = ifaces.trim().toLowerCase().replace(/,+/g, '|');
+        ifaces = ifaces.trim().replace(/,+/g, '|');
         ifacesArray = ifaces.split('|');
       }
 


### PR DESCRIPTION
Some Linux devices may have default network interface names that include uppercase letters. For example, in my environment, an interface is named enP8p1s0.

Currently, the code assumes interface names are lowercase and fails to locate the directory `/sys/class/net/<ifacename>/`. This change ensures that interface names with uppercase letters are handled correctly, allowing the system to find the corresponding directory regardless of case.