### PR TITLE
fix: fix MacOS used memory value

### DIFF
--- a/lib/memory.js
+++ b/lib/memory.js
@@ -258,13 +258,21 @@ function mem(callback) {
           util.noop();
         }
         try {
-          exec('vm_stat 2>/dev/null | egrep "Pages active|Pages inactive"', (error, stdout) => {
+          exec('vm_stat 2>/dev/null | egrep "Pages active|Pages inactive|Pages speculative|Pages wired down|Pages occupied by compressor|Pages purgeable|File-backed pages"', (error, stdout) => {
             if (!error) {
               let lines = stdout.toString().split('\n');
               result.active = (parseInt(util.getValue(lines, 'Pages active'), 10) || 0) * pageSize;
               result.reclaimable = (parseInt(util.getValue(lines, 'Pages inactive'), 10) || 0) * pageSize;
               result.buffcache = result.used - result.active;
               result.available = result.free + result.buffcache;
+
+              const specultive = (parseInt(util.getValue(lines, 'Pages speculative'), 10) || 0) * pageSize;
+              const wired = (parseInt(util.getValue(lines, 'Pages wired down'), 10) || 0) * pageSize;
+              const compressed = (parseInt(util.getValue(lines, 'Pages occupied by compressor'), 10) || 0) * pageSize; 
+              const purgeable = (parseInt(util.getValue(lines, 'Pages purgeable'), 10) || 0) * pageSize;
+              const fileBacked = (parseInt(util.getValue(lines, 'File-backed pages'), 10) || 0) * pageSize;
+
+              result.used = result.active + result.reclaimable + specultive + wired + compressed - purgeable - fileBacked;
             }
             exec('sysctl -n vm.swapusage 2>/dev/null', (error, stdout) => {
               if (!error) {

--- a/lib/memory.js
+++ b/lib/memory.js
@@ -266,13 +266,13 @@ function mem(callback) {
               result.buffcache = result.used - result.active;
               result.available = result.free + result.buffcache;
 
-              const specultive = (parseInt(util.getValue(lines, 'Pages speculative'), 10) || 0) * pageSize;
+              const speculative = (parseInt(util.getValue(lines, 'Pages speculative'), 10) || 0) * pageSize;
               const wired = (parseInt(util.getValue(lines, 'Pages wired down'), 10) || 0) * pageSize;
               const compressed = (parseInt(util.getValue(lines, 'Pages occupied by compressor'), 10) || 0) * pageSize; 
               const purgeable = (parseInt(util.getValue(lines, 'Pages purgeable'), 10) || 0) * pageSize;
               const fileBacked = (parseInt(util.getValue(lines, 'File-backed pages'), 10) || 0) * pageSize;
 
-              result.used = result.active + result.reclaimable + specultive + wired + compressed - purgeable - fileBacked;
+              result.used = result.active + result.reclaimable + speculative + wired + compressed - purgeable - fileBacked;
             }
             exec('sysctl -n vm.swapusage 2>/dev/null', (error, stdout) => {
               if (!error) {


### PR DESCRIPTION
Hi!

We've been using `systeminformation` package to monitor system stats across our servers and we've noticed that on MacOS the `used` field doesn't really correspond to the value visible in Activity Monitor.

For the time being we've added a fix on our side but it'd be great to actually simply have this in this package.

Before the fix:

```
{
  total: 34359738368,
  free: 647348224,
  used: 33712390144,
  active: 10846011392,
  available: 23513726976,
  buffers: 0,
  cached: 0,
  slab: 0,
  buffcache: 22866378752,
  reclaimable: 10776772608,
  swaptotal: 5368709120,
  swapused: 4009167421.44,
  swapfree: 1359541698.56,
  writeback: null,
  dirty: null
}
```

Activity Monitor:
<img width="622" height="106" alt="image" src="https://github.com/user-attachments/assets/29c37b78-e415-4af3-913a-455967ff68c0" />

`33712390144` (used) is equal to 31.39GB, while Activity Monitor shows 26.82GB.

After the fix:

```
{
  total: 34359738368,
  free: 289456128,
  used: 27864104960,
  active: 11005493248,
  available: 23354245120,
  buffers: 0,
  cached: 0,
  slab: 0,
  buffcache: 23064788992,
  reclaimable: 10964779008,
  swaptotal: 5368709120,
  swapused: 4009167421.44,
  swapfree: 1359541698.56,
  writeback: null,
  dirty: null
}
```

Activity Monitor:
<img width="625" height="111" alt="image" src="https://github.com/user-attachments/assets/01c34a1e-33be-441c-80e0-97d6b3dff8e0" />

In this case `27864104960` is equal to 25.90GB, while Activity Monitor shows 26.82GB (it jumps around a bit so taking a perfect screenshot isn't easy, but it's around 26GBs for both now)

---

Some questions I have (because the implementation is very rough right now):
  - is that a breaking change in your opinion? Could be considered one because values will change for everyone that uses the `used` field
      - should we expose a different field than `used`? To both keep the semantics of what it means across different platforms and not introduce a breaking change?
  - does it even make sense? Maybe our understanding of used memory on MacOS is wrong?
  - should the package expose fields used in the calculation (e.g. `speculative`, `wired`)?
  - should we also change `result.available` to be `result.total - result.used`?


Thank you and hope we can work something out here :smile: