### PR TITLE
ci: update checkout and setup-node actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,8 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install


### PR DESCRIPTION
Updates the CI workflow to use current GitHub-maintained action versions.

Changes:
- `actions/checkout@v1` -> `actions/checkout@v4`
- `actions/setup-node@v1` -> `actions/setup-node@v4`

Validation:
- YAML syntax verified
- Only `.github/workflows/test.yml` modified

Scope: `.github/workflows/test.yml` only.