### PR TITLE
fix: stop osInfo() from silently returning empty defaults on non-UEFI Linux

### DIFF
--- a/src/linux/os-info.ts
+++ b/src/linux/os-info.ts
@@ -57,7 +57,7 @@ const linuxIsUefi = async () => {
   if (await fileExists('/sys/firmware/efi')) {
     return true;
   } else {
-    const { stdout } = await exec('dmesg | grep -E "EFI v"', execOptsLinux);
+    const { stdout } = await execSave('dmesg | grep -E "EFI v"', execOptsLinux);
     return stdout.split('\n').length > 0 && stdout.indexOf('EFI') >= 0;
   }
 };


### PR DESCRIPTION
I was checking out `displayServer` in the v6 beta. On my regular PC it correctly showed `wayland`, but on a Raspberry Pi running Wayland it came back as `''`. Digging in, I found the cause: `linuxIsUefi()` uses `exec` instead of `execSave` for its `dmesg` fallback. On any non-UEFI system (like the Pi), `grep` finds nothing and `exec` throws, which makes `osInfo()` fall back to empty defaults entirely.

This PR fixes it by switching to `execSave`, which doesn't throw. Tested on a Raspberry Pi on both Wayland, X11, and tty - `osInfo()` now returns correct values in these cases.